### PR TITLE
refactor: make site generator config-driven with config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ $ python3 fetch_bsky.py     # fetch new posts from Bluesky
 $ python3 gen.py            # generate static site in dist/
 $ python3 deploy_vercel.py  # deploy dist/ to Vercel
 $ ./run.sh                  # run all three in sequence
+
+See [config.md](config.md) for the full configuration reference.
 ```
 
 ## Deployment

--- a/bsky/feed.py
+++ b/bsky/feed.py
@@ -26,6 +26,24 @@ def _post_url(uri, handle):
     return f'https://bsky.app/profile/{handle}/post/{_rkey(uri)}'
 
 
+# Facets use byte offsets into the UTF-8 encoded text
+def _apply_facets(text, facets):
+    if not facets:
+        return text
+    sorted_facets = sorted(facets, key=lambda f: f['index']['byteStart'], reverse=True)
+    text_bytes = text.encode('utf-8')
+    for facet in sorted_facets:
+        for feature in facet.get('features', []):
+            if feature.get('$type') == 'app.bsky.richtext.facet#link':
+                uri = feature.get('uri', '')
+                if not uri:
+                    continue
+                start = facet['index']['byteStart']
+                end = facet['index']['byteEnd']
+                text_bytes = text_bytes[:start] + uri.encode('utf-8') + text_bytes[end:]
+    return text_bytes.decode('utf-8')
+
+
 def fetch_feed(client, actor, cursor=None):
     params = {'actor': actor, 'limit': 100}
     if cursor:
@@ -48,7 +66,7 @@ def transform_feed_item(item, actor):
     parent_id = record['reply'].get('parent', {}).get('uri') if is_reply else None
 
     created_at = record.get('createdAt', '')
-    content = record.get('text', '')
+    content = _apply_facets(record.get('text', ''), record.get('facets'))
     if not created_at:
         return None
 

--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
     "url": null
   },
   "radius": "0.75rem",
+  "base_font_size": "1rem",
   "layout": {
     "header": ["logo", "source_link", "dark_mode_toggle"],
     "sidebar": ["calendar"],

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   "base_font_size": "1rem",
   "layout": {
     "header": ["logo", "source_link", "dark_mode_toggle"],
-    "sidebar": ["calendar", "quick_nav"],
+    "sidebar": ["quick_nav", "calendar"],
     "content": ["description"]
   },
   "widgets": {
@@ -18,7 +18,8 @@
     "source_link": { "text": "Source", "url": "https://github.com/toxdes/chronobsky" },
     "dark_mode_toggle": {},
     "calendar": {},
-    "description": { "text": "{count} posts from @{handle} on bsky.social" }
+    "description": { "text": "{count} posts from @{handle} on bsky.social" },
+    "quick_nav":{}
   },
   "theme": {
     "light": {

--- a/config.json
+++ b/config.json
@@ -1,29 +1,22 @@
 {
+  "version": 2,
   "font": {
     "family": "Inter",
     "weights": [400, 500, 600],
     "source": "google",
     "url": null
   },
-  "logo": {
-    "visible": true,
-    "text": "Chronobsky",
-    "url": "#"
+  "layout": {
+    "header": ["logo", "source_link", "dark_mode_toggle"],
+    "sidebar": ["calendar"],
+    "content": ["description"]
   },
-  "description": {
-    "visible": true,
-    "text": "{count} posts from @{handle} on bsky.social"
-  },
-  "source_link": {
-    "visible": true,
-    "text": "Source",
-    "url": "https://github.com/toxdes/chronobsky"
-  },
-  "dark_mode_toggle": {
-    "visible": true
-  },
-  "calendar": {
-    "visible": true
+  "widgets": {
+    "logo": { "text": "Chronobsky", "url": "#" },
+    "source_link": { "text": "Source", "url": "https://github.com/toxdes/chronobsky" },
+    "dark_mode_toggle": {},
+    "calendar": {},
+    "description": { "text": "{count} posts from @{handle} on bsky.social" }
   },
   "theme": {
     "light": {

--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "source": "google",
     "url": null
   },
+  "radius": "0.75rem",
   "layout": {
     "header": ["logo", "source_link", "dark_mode_toggle"],
     "sidebar": ["calendar"],

--- a/config.json
+++ b/config.json
@@ -1,0 +1,50 @@
+{
+  "font": {
+    "family": "Inter",
+    "weights": [400, 500, 600],
+    "source": "google",
+    "url": null
+  },
+  "logo": {
+    "visible": true,
+    "text": "Chronobsky",
+    "url": "#"
+  },
+  "description": {
+    "visible": true,
+    "text": "{count} posts from @{handle} on bsky.social"
+  },
+  "source_link": {
+    "visible": true,
+    "text": "Source",
+    "url": "https://github.com/toxdes/chronobsky"
+  },
+  "dark_mode_toggle": {
+    "visible": true
+  },
+  "calendar": {
+    "visible": true
+  },
+  "theme": {
+    "light": {
+      "bg": "#ffffff",
+      "text": "#0f172a",
+      "border": "#e2e8f0",
+      "accent": "#2563eb",
+      "muted": "#64748b",
+      "reply_bg": "#f1f5f9",
+      "header_bg": "rgba(255, 255, 255, 0.85)",
+      "link_icon": "#cbd5e1"
+    },
+    "dark": {
+      "bg": "#0f172a",
+      "text": "#e2e8f0",
+      "border": "#1e293b",
+      "accent": "#60a5fa",
+      "muted": "#94a3b8",
+      "reply_bg": "#1e293b",
+      "header_bg": "rgba(15, 23, 42, 0.85)",
+      "link_icon": "#475569"
+    }
+  }
+}

--- a/config.json
+++ b/config.json
@@ -6,11 +6,11 @@
     "source": "google",
     "url": null
   },
-  "radius": "0.75rem",
+  "border_radius": "0.75rem",
   "base_font_size": "1rem",
   "layout": {
     "header": ["logo", "source_link", "dark_mode_toggle"],
-    "sidebar": ["calendar"],
+    "sidebar": ["calendar", "quick_nav"],
     "content": ["description"]
   },
   "widgets": {

--- a/config.md
+++ b/config.md
@@ -1,0 +1,151 @@
+# Configuration
+
+The site generator reads `config.json` from the project root by default. A custom path can be specified via `--config`:
+
+```
+python3 gen.py --config /path/to/config.json
+```
+
+If no config file is found, built-in defaults are used. A config file only needs to specify the values you want to override -- missing keys inherit from defaults.
+
+## Top-level keys
+
+```json
+{
+  "version": 2,
+  "font": { ... },
+  "border_radius": "0.75rem",
+  "base_font_size": "1rem",
+  "layout": { ... },
+  "widgets": { ... },
+  "theme": { ... }
+}
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `version` | number | `2` | Config format version. A warning is shown if the file has a higher version than the generator supports. |
+| `font` | object | see below | Font family, weights, and loading method. |
+| `border_radius` | string | `"0.75rem"` | Global border radius for all cards, buttons, and modals. Set to `"0"` for sharp corners. Any CSS length value. |
+| `base_font_size` | string | `"1rem"` | Root font size set on `<html>`. All `rem` values in the site scale relative to this. |
+| `layout` | object | see below | Defines which widgets appear in which section and their order. |
+| `widgets` | object | see below | Configuration for each individual widget. |
+| `theme` | object | see below | Light and dark color palettes. |
+
+## `font`
+
+```json
+{
+  "family": "Inter",
+  "weights": [400, 500, 600],
+  "source": "google",
+  "url": null
+}
+```
+
+| Key | Type | Description |
+|---|---|---|
+| `family` | string | Font family name (e.g. `"Inter"`, `"Funnel Sans"`). |
+| `weights` | array | Font weights to load (e.g. `[400, 500, 600]`). |
+| `source` | `"google"` or `"custom"` | `"google"` generates a Google Fonts `<link>` tag. `"custom"` uses the `url` field as a CSS `<link>`. |
+| `url` | string or null | When `source` is `"custom"`, this should be a URL to a CSS file with `@font-face` declarations. |
+
+## `layout`
+
+```json
+{
+  "header": ["logo", "source_link", "dark_mode_toggle"],
+  "sidebar": ["calendar", "quick_nav"],
+  "content": ["description"]
+}
+```
+
+Each key is an ordered array of widget names. A widget listed in multiple sections will appear in each. A widget not listed in any section is not rendered.
+
+### Placement slots
+
+| Slot | Location | Description |
+|---|---|---|
+| `header` | Inside `<nav>` in the sticky header | Rendered left to right in the given order. `logo` is special -- it sits outside `<nav>` but its position in the array is ignored; it always appears first. |
+| `sidebar` | Right-hand sticky sidebar | Rendered top to bottom. Empty array means no sidebar wrapper is generated -- content centers naturally. |
+| `content` | Above the post timeline | Rendered top to bottom above the first day's posts. |
+
+## `widgets`
+
+### `logo`
+
+```json
+{
+  "text": "Chronobsky",
+  "url": "#"
+}
+```
+
+The site title in the header. Links to the given URL.
+
+### `source_link`
+
+```json
+{
+  "text": "Source",
+  "url": "https://github.com/toxdes/chronobsky"
+}
+```
+
+A text link in the header nav.
+
+### `dark_mode_toggle`
+
+```json
+{}
+```
+
+A button that toggles between light and dark themes. Preference is persisted in `localStorage`. No configuration options currently.
+
+### `calendar`
+
+```json
+{}
+```
+
+A sticky calendar widget in the sidebar showing months with posts. Days with posts are highlighted. On mobile, opens as a modal via the sidebar toggle button. No configuration options currently.
+
+### `quick_nav`
+
+```json
+{
+  "label_today": "Today",
+  "label_week": "Week",
+  "label_month": "Month",
+  "label_year": "Year"
+}
+```
+
+Shortcut links that scroll to the nearest available post for the current period. Each label is customizable.
+
+### `description`
+
+```json
+{
+  "text": "{count} posts from @{handle} on bsky.social"
+}
+```
+
+A short intro text shown above the post timeline. Supports `{count}` (total post count) and `{handle}` (Bluesky handle from `.env`) placeholders.
+
+## `theme`
+
+Two sub-objects: `light` and `dark`. Each contains the same set of CSS custom property values.
+
+| Key | CSS variable | Light (default) | Dark (default) | Description |
+|---|---|---|---|---|
+| `bg` | `--bg` | `#ffffff` | `#0f172a` | Page background |
+| `text` | `--text` | `#0f172a` | `#e2e8f0` | Body text color |
+| `border` | `--border` | `#e2e8f0` | `#1e293b` | Border color for cards, headers, dividers |
+| `accent` | `--accent` | `#2563eb` | `#60a5fa` | Primary accent color for links, badges, headings |
+| `muted` | `--muted` | `#64748b` | `#94a3b8` | Secondary/muted text color |
+| `reply_bg` | `--reply-bg` | `#f1f5f9` | `#1e293b` | Background for reply cards |
+| `header_bg` | `--header-bg` | `rgba(255,255,255,0.85)` | `rgba(15,23,42,0.85)` | Header background (semi-transparent for blur effect) |
+| `link_icon` | `--link-icon` | `#cbd5e1` | `#475569` | Color for the external link icon on each post |
+
+All values are standard CSS values -- hex, rgb, rgba, or any valid color syntax.

--- a/fetch_bsky.py
+++ b/fetch_bsky.py
@@ -70,6 +70,7 @@ def _download_and_save(posts, tweets_dir):
 def _fetch_all(client, handle):
     import bsky.config as cfg_mod
     import bsky.media as media_mod
+    import bsky.storage as storage_mod
     import shutil
 
     temp_dir = os.path.join(cfg_mod.ROOT, 'tweets_new')
@@ -80,6 +81,7 @@ def _fetch_all(client, handle):
     old_tweets_dir = cfg_mod.TWEETS_DIR
     cfg_mod.TWEETS_DIR = temp_dir
     media_mod.TWEETS_DIR = temp_dir
+    storage_mod.TWEETS_DIR = temp_dir
 
     try:
         posts = _fetch_posts(client, handle, cutoff=None)
@@ -116,6 +118,7 @@ def _fetch_all(client, handle):
     finally:
         cfg_mod.TWEETS_DIR = old_tweets_dir
         media_mod.TWEETS_DIR = old_tweets_dir
+        storage_mod.TWEETS_DIR = old_tweets_dir
 
 
 def main():

--- a/fetch_bsky.py
+++ b/fetch_bsky.py
@@ -6,6 +6,7 @@ from bsky.feed import fetch_feed, transform_feed_item
 from bsky.storage import save_posts
 from bsky.media import download_images
 from bsky.state import load, save
+import argparse
 import os
 import sys
 import urllib.request
@@ -26,7 +27,102 @@ def _ping_counter():
 
 
 # getAuthorFeed returns items newest-first; the cutoff prevents re-processing old items
+def _fetch_posts(client, handle, cutoff=None):
+    posts = []
+    cursor = None
+    page = 0
+    done = False
+    while not done:
+        page += 1
+        print(f'Fetching page {page}...')
+        try:
+            items, cursor = fetch_feed(client, handle, cursor=cursor)
+        except HTTPError as e:
+            print(f'  Feed fetch error: {e}')
+            break
+        if not items:
+            break
+        for item in items:
+            post = transform_feed_item(item, handle)
+            if not post:
+                continue
+            if cutoff and post['created_at'] <= cutoff:
+                done = True
+                break
+            posts.append(post)
+        if not cursor:
+            break
+    return posts
+
+
+def _download_and_save(posts, tweets_dir):
+    for post in posts:
+        if post['images']:
+            parts = post['created_at'].split('T')[0].split('-')
+            media_dir = os.path.join(tweets_dir, parts[0], parts[1])
+            post['images_local_path'] = download_images(
+                post['images'], post['id'], media_dir,
+            )
+    print('Saving posts...')
+    save_posts(posts)
+
+
+def _fetch_all(client, handle):
+    import bsky.config as cfg_mod
+    import bsky.media as media_mod
+    import shutil
+
+    temp_dir = os.path.join(cfg_mod.ROOT, 'tweets_new')
+    if os.path.exists(temp_dir):
+        shutil.rmtree(temp_dir)
+    os.makedirs(temp_dir, exist_ok=True)
+
+    old_tweets_dir = cfg_mod.TWEETS_DIR
+    cfg_mod.TWEETS_DIR = temp_dir
+    media_mod.TWEETS_DIR = temp_dir
+
+    try:
+        posts = _fetch_posts(client, handle, cutoff=None)
+        if not posts:
+            print('No posts found.')
+            return
+
+        print(f'Fetched {len(posts)} posts/replies.')
+
+        for post in posts:
+            if post['images']:
+                parts = post['created_at'].split('T')[0].split('-')
+                media_dir = os.path.join(temp_dir, parts[0], parts[1])
+                post['images_local_path'] = download_images(
+                    post['images'], post['id'], media_dir,
+                )
+
+        print('Saving posts...')
+        save_posts(posts)
+
+        # Success — swap temp into place
+        if os.path.exists(old_tweets_dir):
+            shutil.rmtree(old_tweets_dir)
+        os.rename(temp_dir, old_tweets_dir)
+
+        newest = max(p['created_at'] for p in posts)
+        save({'latest_created_at': newest})
+        print(f'Done. Archived {len(posts)} posts.')
+    except BaseException:
+        # Failure — clean up temp, keep originals intact
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
+        raise
+    finally:
+        cfg_mod.TWEETS_DIR = old_tweets_dir
+        media_mod.TWEETS_DIR = old_tweets_dir
+
+
 def main():
+    parser = argparse.ArgumentParser(description='Fetch Bluesky posts and archive them locally.')
+    parser.add_argument('--all', action='store_true', help='Fetch all posts from scratch (destructive, replaces existing archive)')
+    args = parser.parse_args()
+
     validate()
 
     client = Client(PDS_URL)
@@ -39,37 +135,15 @@ def main():
         print(f'Auth failed: {e}')
         sys.exit(1)
 
+    if args.all:
+        _fetch_all(client, HANDLE)
+        _ping_counter()
+        return
+
     state = load()
     cutoff = state.get('latest_created_at')
 
-    new_posts = []
-    cursor = None
-    page = 0
-    done = False
-
-    while not done:
-        page += 1
-        print(f'Fetching page {page}...')
-        try:
-            items, cursor = fetch_feed(client, HANDLE, cursor=cursor)
-        except HTTPError as e:
-            print(f'  Feed fetch error: {e}')
-            break
-
-        if not items:
-            break
-
-        for item in items:
-            post = transform_feed_item(item, HANDLE)
-            if not post:
-                continue
-            if cutoff and post['created_at'] <= cutoff:
-                done = True
-                break
-            new_posts.append(post)
-
-        if not cursor:
-            break
+    new_posts = _fetch_posts(client, HANDLE, cutoff=cutoff)
 
     if not new_posts:
         print('No new posts.')
@@ -78,16 +152,7 @@ def main():
 
     print(f'Fetched {len(new_posts)} new posts/replies.')
 
-    for post in new_posts:
-        if post['images']:
-            parts = post['created_at'].split('T')[0].split('-')
-            media_dir = os.path.join(TWEETS_DIR, parts[0], parts[1])
-            post['images_local_path'] = download_images(
-                post['images'], post['id'], media_dir,
-            )
-
-    print('Saving posts...')
-    save_posts(new_posts)
+    _download_and_save(new_posts, TWEETS_DIR)
 
     newest = max(p['created_at'] for p in new_posts)
     save({'latest_created_at': newest})

--- a/gen.py
+++ b/gen.py
@@ -248,8 +248,7 @@ def render_day(date_str, posts, known_ids):
 
 
 def render_calendar_sidebar():
-    return '''<aside class="cal-sidebar">
-  <div id="calendar">
+    return '''  <div id="calendar">
     <div class="cal-header">
       <button id="cal-prev" class="cal-nav">&lt;</button>
       <span id="cal-label" class="cal-label"></span>
@@ -261,18 +260,17 @@ def render_calendar_sidebar():
       </thead>
       <tbody id="cal-body"></tbody>
     </table>
-  </div>
-</aside>'''
+  </div>'''
 
 
-def render_calendar_modal():
-    return '''<div id="cal-modal" class="cal-modal-overlay" hidden>
-  <div class="cal-modal-box">
-    <div class="cal-modal-header">
-      <span class="cal-modal-title">Calendar</span>
-      <button id="cal-modal-close" class="cal-modal-close">&times;</button>
+def render_sidebar_modal():
+    return '''<div id="sidebar-modal" class="sidebar-modal-overlay" hidden>
+  <div class="sidebar-modal-box">
+    <div class="sidebar-modal-header">
+      <span class="sidebar-modal-title">Navigate</span>
+      <button id="sidebar-modal-close" class="sidebar-modal-close">&times;</button>
     </div>
-    <div id="cal-modal-body"></div>
+    <div id="sidebar-modal-body"></div>
   </div>
 </div>'''
 
@@ -296,7 +294,7 @@ def _nav_item_html(name, cfg, all_dates=None):
     if name == 'dark_mode_toggle':
         return '<button id="theme-toggle" aria-label="Toggle theme">🌚</button>'
     if name == 'calendar':
-        return '<button id="cal-toggle" class="cal-toggle">Cal</button>'
+        return '<button id="sidebar-toggle" class="sidebar-toggle">&#8942;</button>'
     if name == 'quick_nav' and all_dates:
         return _quick_nav_html(cfg, all_dates)
     return ''
@@ -352,12 +350,12 @@ def _resolve_quick_nav_dates(all_dates):
 def _quick_nav_html(cfg, all_dates):
     w = cfg['widgets']['quick_nav']
     t, wd, m, y = _resolve_quick_nav_dates(all_dates)
-    return f'''<div class="quick-nav">
-  <a href="#{t}" class="qn-btn">{_escape(w.get('label_today', 'Today'))}</a>
-  <a href="#{wd}" class="qn-btn">{_escape(w.get('label_week', 'Week'))}</a>
-  <a href="#{m}" class="qn-btn">{_escape(w.get('label_month', 'Month'))}</a>
+    return f'''<p class="quick-nav">
+  Jump to: <a href="#{t}" class="qn-btn">{_escape(w.get('label_today', 'Today'))}</a>,
+  <a href="#{wd}" class="qn-btn">{_escape(w.get('label_week', 'Week'))}</a>,
+  <a href="#{m}" class="qn-btn">{_escape(w.get('label_month', 'Month'))}</a>,
   <a href="#{y}" class="qn-btn">{_escape(w.get('label_year', 'Year'))}</a>
-</div>'''
+</p>'''
 
 
 def generate_html(days, known_ids, total, cfg):
@@ -387,12 +385,14 @@ def generate_html(days, known_ids, total, cfg):
         nav_items.append(_nav_item_html('calendar', cfg, all_dates))
     nav_html = '\n      '.join(nav_items)
 
-    # Sidebar
+    # Sidebar — wrap all widgets in a single column
     sidebar_html = ''
     for name in layout.get('sidebar', []):
         html = _sidebar_html(name, cfg, all_dates)
         if html:
             sidebar_html += html
+    if sidebar_html:
+        sidebar_html = f'<aside class="sidebar">\n{sidebar_html}\n</aside>'
 
     # Content above posts
     content_top = ''
@@ -407,7 +407,7 @@ def generate_html(days, known_ids, total, cfg):
   <img id="modal-img" src="" alt="">
 </div>'''
     if sidebar_html:
-        modals += render_calendar_modal()
+        modals += render_sidebar_modal()
 
     wrap_open = f'<div class="page-wrap">' if sidebar_html else ''
     wrap_close = '</div>' if sidebar_html else ''
@@ -511,14 +511,14 @@ header nav { display: flex; align-items: center; gap: 0.75rem; }
 #theme-toggle:hover { border-color: var(--accent); }'''
 
 
-def _cal_toggle_css():
-    return '''.cal-toggle {
+def _sidebar_toggle_css():
+    return '''.sidebar-toggle {
   background: none; border: 1px solid var(--border); border-radius: var(--radius);
-  padding: 0.375rem 0.625rem; font-size: 0.8125rem; font-weight: 500; cursor: pointer;
+  padding: 0.375rem 0.625rem; font-size: 1.125rem; cursor: pointer;
   color: var(--muted); line-height: 1; display: none;
   transition: color .2s, border-color .2s;
 }
-.cal-toggle:hover { color: var(--accent); border-color: var(--accent); }'''
+.sidebar-toggle:hover { color: var(--accent); border-color: var(--accent); }'''
 
 def _layout_css():
     return '''/* ── Page layout ──────────────────────────────────── */
@@ -607,22 +607,13 @@ def _image_css():
 
 def _quick_nav_css():
     return '''/* ── Quick nav ──────────────────────────────────── */
-.quick-nav { display: flex; gap: 0.375rem; }
-.qn-btn {
-  flex: 1; text-align: center; padding: 0.3125rem 0;
-  font-size: 0.75rem; font-weight: 500; color: var(--accent);
-  text-decoration: none; border: 1px solid var(--border);
-  border-radius: var(--radius);
-  transition: background .2s, border-color .2s;
-}
-.qn-btn:hover {
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-  border-color: var(--accent);
-}'''
+.quick-nav { font-size: 0.75rem; color: var(--muted); }
+.qn-btn { font-weight: 500; color: var(--accent); text-decoration: none; }
+.qn-btn:hover { text-decoration: underline; }'''
 
 def _calendar_sidebar_css():
-    return '''/* ── Calendar sidebar ────────────────────────────── */
-.cal-sidebar { flex: 0 0 220px; position: sticky; top: 4.375rem; }
+    return '''/* ── Calendar ──────────────────────────────────── */
+.sidebar { flex: 0 0 220px; position: sticky; top: 4.375rem; display: flex; flex-direction: column; gap: 0.75rem; }
 #calendar {
   border: 1px solid var(--border); border-radius: var(--radius);
   padding: 0.75rem; overflow: hidden; transition: border-color .3s;
@@ -650,25 +641,26 @@ def _calendar_sidebar_css():
 .cal-grid td a:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); color: var(--accent); }
 .cal-grid td a.active { color: var(--accent); font-weight: 600; }'''
 
-def _cal_modal_css():
-    return '''/* ── Calendar modal (mobile) ────────────────────── */
-.cal-modal-overlay {
+def _sidebar_modal_css():
+    return '''/* ── Sidebar modal (mobile) ────────────────────── */
+.sidebar-modal-overlay {
   position: fixed; inset: 0; z-index: 200;
   background: rgba(0, 0, 0, 0.5);
   display: flex; align-items: center; justify-content: center; cursor: pointer;
 }
-.cal-modal-overlay[hidden] { display: none; }
-.cal-modal-box {
+.sidebar-modal-overlay[hidden] { display: none; }
+.sidebar-modal-box {
   background: var(--bg); border-radius: var(--radius); padding: 1.25rem;
   width: 300px; cursor: default; transition: background .3s;
 }
-.cal-modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
-.cal-modal-title { font-size: 0.9375rem; font-weight: 600; color: var(--text); }
-.cal-modal-close {
+.sidebar-modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+.sidebar-modal-title { font-size: 0.9375rem; font-weight: 600; color: var(--text); }
+.sidebar-modal-close {
   background: none; border: none; font-size: 1.375rem; cursor: pointer;
   color: var(--muted); padding: 0; line-height: 1;
 }
-.cal-modal-close:hover { color: var(--text); }'''
+.sidebar-modal-close:hover { color: var(--text); }
+#sidebar-modal .sidebar { display: flex; }'''
 
 def _lightbox_css():
     return '''/* ── Image lightbox ─────────────────────────────── */
@@ -691,8 +683,8 @@ def _responsive_css(cal_visible):
     parts = ['/* ── Responsive ─────────────────────────────────── */',
              '@media (max-width: 800px) {']
     if cal_visible:
-        parts.append('  .cal-sidebar { display: none; }')
-        parts.append('  .cal-toggle { display: inline-flex; align-items: center; }')
+        parts.append('  .sidebar { display: none; }')
+        parts.append('  .sidebar-toggle { display: inline-flex; align-items: center; }')
     parts.extend([
         '  .page-wrap, main { padding: 1.5rem 1rem 3.75rem; }',
         '  main { flex: none; max-width: none; }',
@@ -708,7 +700,7 @@ def _responsive_css(cal_visible):
 def _print_css(cal_visible):
     hide = 'header, .post-link'
     if cal_visible:
-        hide += ', .cal-sidebar, .cal-toggle'
+        hide += ', .sidebar, .sidebar-toggle'
     return f'/* ── Print ──────────────────────────────────────── */\n@media print {{ {hide} {{ display: none; }} }}'
 
 
@@ -726,9 +718,9 @@ def generate_style_css(cfg):
         _image_css(),
     ]
     if has_cal:
-        parts.append(_cal_toggle_css())
+        parts.append(_sidebar_toggle_css())
         parts.append(_calendar_sidebar_css())
-        parts.append(_cal_modal_css())
+        parts.append(_sidebar_modal_css())
     if has_qn:
         parts.append(_quick_nav_css())
     parts.append(_lightbox_css())
@@ -852,26 +844,35 @@ LIGHTBOX_JS = '''(function() {
 })();'''
 
 
-CALENDAR_MODAL_JS = '''(function() {
-  var calModal = document.getElementById('cal-modal');
-  var calBody = document.getElementById('cal-modal-body');
-  var calToggle = document.getElementById('cal-toggle');
-  var calClose = document.getElementById('cal-modal-close');
+SIDEBAR_MODAL_JS = '''(function() {
+  var calModal = document.getElementById('sidebar-modal');
+  var calBody = document.getElementById('sidebar-modal-body');
+  var calToggle = document.getElementById('sidebar-toggle');
+  var calClose = document.getElementById('sidebar-modal-close');
   if (!calToggle || !calModal) return;
 
-  function openCal() {
-    var src = document.getElementById('calendar');
-    if (!src) return;
-    var clone = src.cloneNode(true);
+  function refreshClone() {
+    var sidebar = document.querySelector('.sidebar');
+    if (!sidebar) return;
+    var clone = sidebar.cloneNode(true);
     calBody.innerHTML = '';
     calBody.appendChild(clone);
-    calModal.removeAttribute('hidden');
+
+    var prevOrig = document.getElementById('cal-prev');
+    var nextOrig = document.getElementById('cal-next');
+    clone.querySelector('#cal-prev').addEventListener('click', function() {
+      if (prevOrig) { prevOrig.click(); setTimeout(refreshClone, 30); }
+    });
+    clone.querySelector('#cal-next').addEventListener('click', function() {
+      if (nextOrig) { nextOrig.click(); setTimeout(refreshClone, 30); }
+    });
+
     clone.querySelectorAll('a[href^="#"]').forEach(function(a) {
       a.addEventListener('click', function() { calModal.setAttribute('hidden', ''); });
     });
   }
 
-  calToggle.addEventListener('click', openCal);
+  calToggle.addEventListener('click', function() { refreshClone(); calModal.removeAttribute('hidden'); });
   calModal.addEventListener('click', function(e) {
     if (e.target === calModal || e.target === calClose) calModal.setAttribute('hidden', '');
   });
@@ -884,7 +885,7 @@ def generate_theme_js(cfg):
         parts.append(THEME_TOGGLE_JS)
     if 'calendar' in cfg['layout'].get('sidebar', []):
         parts.append(CALENDAR_JS)
-        parts.append(CALENDAR_MODAL_JS)
+        parts.append(SIDEBAR_MODAL_JS)
     parts.append(LIGHTBOX_JS)
     return '\n\n'.join(parts) + '\n'
 

--- a/gen.py
+++ b/gen.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import json
 import os
 import re
@@ -32,6 +33,7 @@ HANDLE = _load_dotenv(_ENV_PATH).get('BLUESKY_HANDLE', 'yourhandle.bsky.social')
 # ── Config ────────────────────────────────────────────────────────
 
 DEFAULT_CONFIG = {
+    "version": 1,
     "font": {
         "family": "Inter",
         "weights": [400, 500, 600],
@@ -93,13 +95,20 @@ def _deep_merge(base, overrides):
     return result
 
 
-def _load_config():
-    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json')
+def _load_config(path=None):
+    if path is None:
+        path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json')
     if not os.path.exists(path):
+        if path != os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'):
+            print(f'Error: config file not found: {path}')
+            sys.exit(1)
         return DEFAULT_CONFIG
     with open(path) as f:
         overrides = json.load(f)
-    return _deep_merge(DEFAULT_CONFIG, overrides)
+    cfg = _deep_merge(DEFAULT_CONFIG, overrides)
+    if cfg.get('version', 1) > 1:
+        print(f'Warning: config version {cfg["version"]} is newer than generator version 1')
+    return cfg
 
 
 # ── Data loading ────────────────────────────────────────────────
@@ -348,20 +357,20 @@ def _theme_vars(cfg):
     return '\n'.join(out)
 
 
-def _reset_css():
-    return '''/* ── Reset ──────────────────────────────────────── */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: smooth; }
+def _reset_css(family):
+    return f'''/* ── Reset ──────────────────────────────────────── */
+*, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+html {{ scroll-behavior: smooth; }}
 
-body {
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+body {{
+  font-family: '{family}', system-ui, -apple-system, sans-serif;
   background: var(--bg);
   color: var(--text);
   line-height: 1.7;
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
   transition: background .3s, color .3s;
-}'''
+}}'''
 
 
 def _header_css():
@@ -588,7 +597,7 @@ def _print_css(cal_visible):
 def generate_style_css(cfg):
     parts = [
         _theme_vars(cfg),
-        _reset_css(),
+        _reset_css(cfg['font']['family']),
         _header_css(),
         _layout_css(),
         _day_css(),
@@ -761,7 +770,11 @@ def generate_theme_js(cfg):
 # ── Main ────────────────────────────────────────────────────────
 
 def main():
-    cfg = _load_config()
+    parser = argparse.ArgumentParser(description='Generate static site from archived Bluesky posts.')
+    parser.add_argument('--config', help='Path to config JSON file (defaults to config.json in project root)')
+    args = parser.parse_args()
+
+    cfg = _load_config(args.config)
     posts = load_all_posts()
     if not posts:
         print('No posts found in tweets/.')

--- a/gen.py
+++ b/gen.py
@@ -41,6 +41,7 @@ DEFAULT_CONFIG = {
         "url": None,
     },
     "radius": "0.75rem",
+    "base_font_size": "1rem",
     "layout": {
         "header": ["logo", "source_link", "dark_mode_toggle"],
         "sidebar": ["calendar"],
@@ -397,7 +398,7 @@ def _theme_vars(cfg):
     return '\n'.join(out)
 
 
-def _reset_css(family):
+def _reset_css(family, base_size):
     return f'''/* ── Reset ──────────────────────────────────────── */
 *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
 html {{ scroll-behavior: smooth; }}
@@ -407,7 +408,7 @@ body {{
   background: var(--bg);
   color: var(--text);
   line-height: 1.7;
-  font-size: 1rem;
+  font-size: {base_size};
   -webkit-font-smoothing: antialiased;
   transition: background .3s, color .3s;
 }}'''
@@ -633,7 +634,7 @@ def generate_style_css(cfg):
     has_cal = 'calendar' in cfg['layout'].get('sidebar', [])
     parts = [
         _theme_vars(cfg),
-        _reset_css(cfg['font']['family']),
+        _reset_css(cfg['font']['family'], cfg['base_font_size']),
         _header_css(),
         _layout_css(),
         _day_css(),

--- a/gen.py
+++ b/gen.py
@@ -40,6 +40,7 @@ DEFAULT_CONFIG = {
         "source": "google",
         "url": None,
     },
+    "radius": "0.75rem",
     "layout": {
         "header": ["logo", "source_link", "dark_mode_toggle"],
         "sidebar": ["calendar"],
@@ -339,7 +340,8 @@ def generate_html(days, known_ids, total, cfg):
     if sidebar_html:
         modals += render_calendar_modal()
 
-    content_wrap = 'page-wrap' if sidebar_html else ''
+    wrap_open = f'<div class="page-wrap">' if sidebar_html else ''
+    wrap_close = '</div>' if sidebar_html else ''
     return f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -360,13 +362,13 @@ def generate_html(days, known_ids, total, cfg):
     </nav>
   </div>
 </header>
-<div class="{content_wrap}">
+{wrap_open}
 <main>
 {content_top}
 {sections}
 </main>
 {sidebar_html}
-</div>
+{wrap_close}
 {modals}
 <script>
 var ACTIVE_DATES = {dates_json};
@@ -380,8 +382,10 @@ var ACTIVE_DATES = {dates_json};
 
 def _theme_vars(cfg):
     t = cfg['theme']
+    radius = cfg.get('radius', '0.75rem')
     out = ['/* ── Variables ────────────────────────────────────── */',
            ':root {']
+    out.append(f'  --radius: {radius};')
     for k, v in t['light'].items():
         out.append(f'  --{k.replace("_", "-")}: {v};')
     out.append('}')
@@ -432,7 +436,7 @@ header nav { display: flex; align-items: center; gap: 0.75rem; }
 }
 .gh-link:hover { color: var(--accent); }
 #theme-toggle {
-  background: none; border: 1px solid var(--border); border-radius: 0.5rem;
+  background: none; border: 1px solid var(--border); border-radius: var(--radius);
   padding: 0.375rem 0.625rem; font-size: 1.125rem; cursor: pointer; line-height: 1;
   transition: border-color .2s;
 }
@@ -441,7 +445,7 @@ header nav { display: flex; align-items: center; gap: 0.75rem; }
 
 def _cal_toggle_css():
     return '''.cal-toggle {
-  background: none; border: 1px solid var(--border); border-radius: 0.5rem;
+  background: none; border: 1px solid var(--border); border-radius: var(--radius);
   padding: 0.375rem 0.625rem; font-size: 0.8125rem; font-weight: 500; cursor: pointer;
   color: var(--muted); line-height: 1; display: none;
   transition: color .2s, border-color .2s;
@@ -454,7 +458,10 @@ def _layout_css():
   max-width: 980px; margin: 0 auto; padding: 2.5rem 1.5rem 5rem;
   display: flex; gap: 2.5rem; align-items: flex-start;
 }
-main { flex: 0 0 680px; max-width: 680px; }
+main {
+  max-width: 680px; margin: 0 auto; padding: 2.5rem 1.5rem 5rem;
+}
+.page-wrap > main { flex: 0 0 680px; margin: 0; padding: 0; }
 .intro {
   margin-bottom: 2.5rem; padding-bottom: 1.5rem;
   border-bottom: 1px solid var(--border);
@@ -478,7 +485,7 @@ def _day_css():
 def _post_css():
     return '''/* ── Post card ──────────────────────────────────── */
 .post {
-  margin-bottom: 1rem; padding: 1rem 1.25rem; border-radius: 0.75rem;
+  margin-bottom: 1rem; padding: 1rem 1.25rem; border-radius: var(--radius);
   border: 1px solid var(--border); scroll-margin-top: 4.375rem;
   transition: border-color .3s, background .3s;
 }
@@ -490,7 +497,7 @@ def _post_css():
 .post-meta time { font-weight: 500; }
 .reply-badge {
   font-size: 0.6875rem; font-weight: 600; color: var(--accent);
-  padding: 0.0625rem 0.375rem; border-radius: 0.25rem;
+  padding: 0.0625rem 0.375rem; border-radius: var(--radius);
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 a.reply-badge { text-decoration: none; transition: background .2s; }
@@ -504,7 +511,7 @@ a.reply-badge:hover { background: color-mix(in srgb, var(--accent) 20%, transpar
 .quote-link {
   display: inline-block; margin-top: 0.625rem; font-size: 0.8125rem; font-weight: 500;
   color: var(--accent); text-decoration: none; padding: 0.1875rem 0.625rem;
-  border-radius: 0.375rem; border: 1px solid var(--border);
+  border-radius: var(--radius); border: 1px solid var(--border);
   transition: background .2s, border-color .2s;
 }
 .quote-link:hover {
@@ -526,7 +533,7 @@ def _image_css():
     return '''/* ── Images ─────────────────────────────────────── */
 .post-images { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
 .post-images img {
-  max-width: 100%; height: auto; border-radius: 0.5rem;
+  max-width: 100%; height: auto; border-radius: var(--radius);
   border: 1px solid var(--border);
 }'''
 
@@ -534,13 +541,13 @@ def _calendar_sidebar_css():
     return '''/* ── Calendar sidebar ────────────────────────────── */
 .cal-sidebar { flex: 0 0 220px; position: sticky; top: 4.375rem; }
 #calendar {
-  border: 1px solid var(--border); border-radius: 0.625rem;
+  border: 1px solid var(--border); border-radius: var(--radius);
   padding: 0.75rem; overflow: hidden; transition: border-color .3s;
 }
 .cal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.625rem; }
 .cal-label { font-size: 0.8125rem; font-weight: 600; color: var(--text); }
 .cal-nav {
-  background: none; border: 1px solid var(--border); border-radius: 0.375rem;
+  background: none; border: 1px solid var(--border); border-radius: var(--radius);
   padding: 0 0.5rem; font-size: 0.875rem; cursor: pointer; color: var(--muted);
   line-height: 1; height: 1.625rem;
   display: flex; align-items: center; justify-content: center;
@@ -569,7 +576,7 @@ def _cal_modal_css():
 }
 .cal-modal-overlay[hidden] { display: none; }
 .cal-modal-box {
-  background: var(--bg); border-radius: 0.875rem; padding: 1.25rem;
+  background: var(--bg); border-radius: var(--radius); padding: 1.25rem;
   width: 300px; cursor: default; transition: background .3s;
 }
 .cal-modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
@@ -588,7 +595,7 @@ def _lightbox_css():
   display: flex; align-items: center; justify-content: center; cursor: pointer;
 }
 .modal-overlay[hidden] { display: none; }
-.modal-overlay img { max-width: 90vw; max-height: 90vh; object-fit: contain; border-radius: 0.25rem; cursor: default; }
+.modal-overlay img { max-width: 90vw; max-height: 90vh; object-fit: contain; border-radius: var(--radius); cursor: default; }
 .modal-close {
   position: fixed; top: 1rem; right: 1rem;
   background: none; border: none; font-size: 2rem; color: #fff;
@@ -604,7 +611,7 @@ def _responsive_css(cal_visible):
         parts.append('  .cal-sidebar { display: none; }')
         parts.append('  .cal-toggle { display: inline-flex; align-items: center; }')
     parts.extend([
-        '  .page-wrap { padding: 1.5rem 1rem 3.75rem; }',
+        '  .page-wrap, main { padding: 1.5rem 1rem 3.75rem; }',
         '  main { flex: none; max-width: none; }',
         '  .page-wrap { display: block; }',
         '  .post { padding: 0.75rem 0.875rem; }',

--- a/gen.py
+++ b/gen.py
@@ -40,11 +40,11 @@ DEFAULT_CONFIG = {
         "source": "google",
         "url": None,
     },
-    "radius": "0.75rem",
+    "border_radius": "0.75rem",
     "base_font_size": "1rem",
     "layout": {
         "header": ["logo", "source_link", "dark_mode_toggle"],
-        "sidebar": ["calendar"],
+        "sidebar": ["calendar", "quick_nav"],
         "content": ["description"],
     },
     "widgets": {
@@ -60,6 +60,12 @@ DEFAULT_CONFIG = {
         "calendar": {},
         "description": {
             "text": "{count} posts from @{handle} on bsky.social",
+        },
+        "quick_nav": {
+            "label_today": "Today",
+            "label_week": "Week",
+            "label_month": "Month",
+            "label_year": "Year",
         },
     },
     "theme": {
@@ -207,7 +213,7 @@ def render_post(post, known_ids):
     if is_reply:
         pid = post['parent_id']
         if pid in known_ids:
-            lines.append(f'    <a href="#{_escape(pid)}" class="reply-badge">↳ Reply</a>')
+            lines.append(f'    <a href="#{_escape(pid)}" class="reply-badge" title="Go to parent post">↳ Reply</a>')
         else:
             lines.append('    <span class="reply-badge">↳ Reply</span>')
     if post.get('post_url'):
@@ -226,7 +232,7 @@ def render_post(post, known_ids):
     quoted_id = post.get('quoted_post_id')
     if quoted_id:
         eq = _escape(quoted_id)
-        lines.append(f'  <a href="#{eq}" class="quote-link">Quoted post</a>')
+        lines.append(f'  <a href="#{eq}" class="quote-link" title="Go to quoted post">Quoted post</a>')
 
     lines.append('</article>')
     return '\n'.join(lines)
@@ -282,7 +288,7 @@ def _render_font_link(cfg):
     return ''
 
 
-def _nav_item_html(name, cfg):
+def _nav_item_html(name, cfg, all_dates=None):
     w = cfg['widgets']
     if name == 'source_link':
         sl = w['source_link']
@@ -291,26 +297,73 @@ def _nav_item_html(name, cfg):
         return '<button id="theme-toggle" aria-label="Toggle theme">🌚</button>'
     if name == 'calendar':
         return '<button id="cal-toggle" class="cal-toggle">Cal</button>'
+    if name == 'quick_nav' and all_dates:
+        return _quick_nav_html(cfg, all_dates)
     return ''
 
 
-def _sidebar_html(name, cfg):
+def _sidebar_html(name, cfg, all_dates=None):
     if name == 'calendar':
         return render_calendar_sidebar()
+    if name == 'quick_nav' and all_dates:
+        return _quick_nav_html(cfg, all_dates)
     return ''
 
 
-def _content_html(name, cfg, total):
+def _content_html(name, cfg, total, all_dates=None):
     if name == 'description':
         desc_text = cfg['widgets']['description'].get('text', '')
         desc_text = desc_text.replace('{count}', f'<span class="post-count">{total}</span>').replace('{handle}', HANDLE)
         return f'<section class="intro"><p>{desc_text}</p></section>'
+    if name == 'quick_nav' and all_dates:
+        return _quick_nav_html(cfg, all_dates)
     return ''
+
+
+def _resolve_quick_nav_dates(all_dates):
+    from datetime import date, timedelta
+    today = date.today()
+    today_str = today.isoformat()
+    monday = (today - timedelta(days=today.weekday())).isoformat()
+    month_start = today.replace(day=1).isoformat()
+    year_start = today.replace(month=1, day=1).isoformat()
+
+    def nearest(target, forward=True):
+        if target in all_dates:
+            return target
+        if forward:
+            for d in all_dates:
+                if d >= target:
+                    return d
+            return all_dates[-1]
+        for d in reversed(all_dates):
+            if d <= target:
+                return d
+        return all_dates[0]
+
+    return (
+        nearest(today_str, forward=False),
+        nearest(monday, forward=True),
+        nearest(month_start, forward=True),
+        nearest(year_start, forward=True),
+    )
+
+
+def _quick_nav_html(cfg, all_dates):
+    w = cfg['widgets']['quick_nav']
+    t, wd, m, y = _resolve_quick_nav_dates(all_dates)
+    return f'''<div class="quick-nav">
+  <a href="#{t}" class="qn-btn">{_escape(w.get('label_today', 'Today'))}</a>
+  <a href="#{wd}" class="qn-btn">{_escape(w.get('label_week', 'Week'))}</a>
+  <a href="#{m}" class="qn-btn">{_escape(w.get('label_month', 'Month'))}</a>
+  <a href="#{y}" class="qn-btn">{_escape(w.get('label_year', 'Year'))}</a>
+</div>'''
 
 
 def generate_html(days, known_ids, total, cfg):
     sections = '\n'.join(render_day(d, ps, known_ids) for d, ps in days.items())
     dates_json = json.dumps(sorted(days.keys()))
+    all_dates = sorted(days.keys())
     font_link = _render_font_link(cfg)
     layout = cfg['layout']
     w = cfg['widgets']
@@ -327,24 +380,24 @@ def generate_html(days, known_ids, total, cfg):
     for name in layout.get('header', []):
         if name == 'logo':
             continue
-        html = _nav_item_html(name, cfg)
+        html = _nav_item_html(name, cfg, all_dates)
         if html:
             nav_items.append(html)
     if has_calendar:
-        nav_items.append(_nav_item_html('calendar', cfg))
+        nav_items.append(_nav_item_html('calendar', cfg, all_dates))
     nav_html = '\n      '.join(nav_items)
 
     # Sidebar
     sidebar_html = ''
     for name in layout.get('sidebar', []):
-        html = _sidebar_html(name, cfg)
+        html = _sidebar_html(name, cfg, all_dates)
         if html:
             sidebar_html += html
 
     # Content above posts
     content_top = ''
     for name in layout.get('content', []):
-        html = _content_html(name, cfg, total)
+        html = _content_html(name, cfg, total, all_dates)
         if html:
             content_top += html
 
@@ -398,7 +451,7 @@ var ACTIVE_DATES = {dates_json};
 
 def _theme_vars(cfg):
     t = cfg['theme']
-    radius = cfg.get('radius', '0.75rem')
+    radius = str(cfg.get('border_radius', '0.75rem'))
     out = ['/* ── Variables ────────────────────────────────────── */',
            ':root {']
     out.append(f'  --radius: {radius};')
@@ -552,6 +605,21 @@ def _image_css():
   border: 1px solid var(--border);
 }'''
 
+def _quick_nav_css():
+    return '''/* ── Quick nav ──────────────────────────────────── */
+.quick-nav { display: flex; gap: 0.375rem; }
+.qn-btn {
+  flex: 1; text-align: center; padding: 0.3125rem 0;
+  font-size: 0.75rem; font-weight: 500; color: var(--accent);
+  text-decoration: none; border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: background .2s, border-color .2s;
+}
+.qn-btn:hover {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-color: var(--accent);
+}'''
+
 def _calendar_sidebar_css():
     return '''/* ── Calendar sidebar ────────────────────────────── */
 .cal-sidebar { flex: 0 0 220px; position: sticky; top: 4.375rem; }
@@ -570,9 +638,9 @@ def _calendar_sidebar_css():
 }
 .cal-nav:hover { color: var(--accent); border-color: var(--accent); }
 .cal-nav:disabled { opacity: 0.25; cursor: default; pointer-events: none; }
-.cal-grid { width: 100%; border-collapse: collapse; font-size: 0.75rem; }
-.cal-grid th { font-weight: 500; color: var(--muted); padding: 0.125rem 0; text-align: center; font-size: 0.6875rem; }
-.cal-grid td { text-align: center; padding: 0.1875rem 0; color: var(--muted); font-size: 0.75rem; }
+.cal-grid { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: 0.75rem; }
+.cal-grid th { font-weight: 500; color: var(--muted); padding: 0.125rem 0; text-align: center; font-size: 0.6875rem; width: calc(100% / 7); }
+.cal-grid td { text-align: center; padding: 0.1875rem 0; color: var(--muted); font-size: 0.75rem; width: calc(100% / 7); }
 .cal-grid td a {
   display: flex; align-items: center; justify-content: center;
   width: 1.5rem; height: 1.5rem; margin: 0 auto;
@@ -646,6 +714,7 @@ def _print_css(cal_visible):
 
 def generate_style_css(cfg):
     has_cal = 'calendar' in cfg['layout'].get('sidebar', [])
+    has_qn = 'quick_nav' in cfg['layout'].get('sidebar', []) or 'quick_nav' in cfg['layout'].get('content', [])
     parts = [
         _theme_vars(cfg),
         _reset_css(cfg['font']['family'], cfg['base_font_size']),
@@ -660,6 +729,8 @@ def generate_style_css(cfg):
         parts.append(_cal_toggle_css())
         parts.append(_calendar_sidebar_css())
         parts.append(_cal_modal_css())
+    if has_qn:
+        parts.append(_quick_nav_css())
     parts.append(_lightbox_css())
     parts.append(_responsive_css(has_cal))
     parts.append(_print_css(has_cal))

--- a/gen.py
+++ b/gen.py
@@ -142,10 +142,10 @@ def build_parent_lookup(posts):
 # ── Formatting ──────────────────────────────────────────────────
 
 def _parse_time(iso_str):
-    s = iso_str.replace('Z', '') if iso_str.endswith('Z') else iso_str
-    if '.' in s:
-        return datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%f')
-    return datetime.strptime(s, '%Y-%m-%dT%H:%M:%S')
+    s = iso_str.replace('Z', '+00:00') if iso_str.endswith('Z') else iso_str
+    dt = datetime.fromisoformat(s)
+    # Convert from UTC to local timezone, fixing time mismatch
+    return dt.astimezone()
 
 
 def format_heading_date(date_str):
@@ -159,12 +159,26 @@ def format_time_short(iso_str):
     return f'{h}:{dt.minute:02d} {"AM" if dt.hour < 12 else "PM"}'
 
 
+def format_time_full(iso_str):
+    dt = _parse_time(iso_str)
+    return dt.strftime('%B %d, %Y at %I:%M %p').lstrip('0').replace(' 0', ' ')
+
+
 def _escape(text):
     return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
 
 
+import re
+_TRAILING_PUNCT = re.compile(r'[.,!?:;\'\")\]}]+$')
+
 def _linkify(text):
-    return re.sub(r'(https?://[^\s<]+)', r'<a href="\1" rel="nofollow">\1</a>', text)
+    def _wrap(m):
+        url = m.group(1)
+        url = _TRAILING_PUNCT.sub('', url)
+        if not url.startswith(('http://', 'https://')):
+            return m.group(0)
+        return f'<a href="{url}" rel="nofollow">{url}</a>'
+    return re.sub(r'(https?://[^\s<]+)', _wrap, text)
 
 
 def content_to_html(text):
@@ -185,10 +199,11 @@ def render_post(post, known_ids):
     eid = _escape(post['id'])
     time_iso = post['created_at']
     time_short = format_time_short(time_iso)
+    time_full = format_time_full(time_iso)
 
     lines = [f'<article class="{cls}" id="{eid}">']
     lines.append('  <div class="post-meta">')
-    lines.append(f'    <time datetime="{_escape(time_iso)}">{_escape(time_short)}</time>')
+    lines.append(f'    <time datetime="{_escape(time_iso)}" title="{_escape(time_full)}">{_escape(time_short)}</time>')
     if is_reply:
         pid = post['parent_id']
         if pid in known_ids:
@@ -401,14 +416,13 @@ def _theme_vars(cfg):
 def _reset_css(family, base_size):
     return f'''/* ── Reset ──────────────────────────────────────── */
 *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
-html {{ scroll-behavior: smooth; }}
+html {{ scroll-behavior: smooth; font-size: {base_size}; }}
 
 body {{
   font-family: '{family}', system-ui, -apple-system, sans-serif;
   background: var(--bg);
   color: var(--text);
   line-height: 1.7;
-  font-size: {base_size};
   -webkit-font-smoothing: antialiased;
   transition: background .3s, color .3s;
 }}'''

--- a/gen.py
+++ b/gen.py
@@ -29,6 +29,78 @@ def _load_dotenv(path):
 _ENV_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '.env')
 HANDLE = _load_dotenv(_ENV_PATH).get('BLUESKY_HANDLE', 'yourhandle.bsky.social')
 
+# ── Config ────────────────────────────────────────────────────────
+
+DEFAULT_CONFIG = {
+    "font": {
+        "family": "Inter",
+        "weights": [400, 500, 600],
+        "source": "google",
+        "url": None,
+    },
+    "logo": {
+        "visible": True,
+        "text": "Chronobsky",
+        "url": "#",
+    },
+    "description": {
+        "visible": True,
+        "text": "{count} posts from @{handle} on bsky.social",
+    },
+    "source_link": {
+        "visible": True,
+        "text": "Source",
+        "url": "https://github.com/toxdes/chronobsky",
+    },
+    "dark_mode_toggle": {
+        "visible": True,
+    },
+    "calendar": {
+        "visible": True,
+    },
+    "theme": {
+        "light": {
+            "bg": "#ffffff",
+            "text": "#0f172a",
+            "border": "#e2e8f0",
+            "accent": "#2563eb",
+            "muted": "#64748b",
+            "reply_bg": "#f1f5f9",
+            "header_bg": "rgba(255, 255, 255, 0.85)",
+            "link_icon": "#cbd5e1",
+        },
+        "dark": {
+            "bg": "#0f172a",
+            "text": "#e2e8f0",
+            "border": "#1e293b",
+            "accent": "#60a5fa",
+            "muted": "#94a3b8",
+            "reply_bg": "#1e293b",
+            "header_bg": "rgba(15, 23, 42, 0.85)",
+            "link_icon": "#475569",
+        },
+    },
+}
+
+
+def _deep_merge(base, overrides):
+    result = dict(base)
+    for k, v in overrides.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
+def _load_config():
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json')
+    if not os.path.exists(path):
+        return DEFAULT_CONFIG
+    with open(path) as f:
+        overrides = json.load(f)
+    return _deep_merge(DEFAULT_CONFIG, overrides)
+
 
 # ── Data loading ────────────────────────────────────────────────
 
@@ -161,10 +233,62 @@ def render_calendar_sidebar():
 </aside>'''
 
 
-def generate_html(days, known_ids, total):
+def _render_font_link(cfg):
+    font = cfg['font']
+    if font['source'] == 'google':
+        weights = ';'.join(str(w) for w in (font['weights'] or [400]))
+        family = font['family'].replace(' ', '+')
+        return f'<link href="https://fonts.googleapis.com/css2?family={family}:wght@{weights}&display=swap" rel="stylesheet">'
+    if font['source'] == 'custom' and font.get('url'):
+        return f'<link rel="stylesheet" href="{_escape(font["url"])}">'
+    return ''
+
+
+def generate_html(days, known_ids, total, cfg):
     sections = '\n'.join(render_day(d, ps, known_ids) for d, ps in days.items())
     dates_json = json.dumps(sorted(days.keys()))
-    cal_sidebar = render_calendar_sidebar()
+    font_link = _render_font_link(cfg)
+
+    # Widget: logo
+    logo = ''
+    if cfg['logo']['visible']:
+        logo = f'<h1><a href="{_escape(cfg["logo"]["url"])}">{_escape(cfg["logo"]["text"])}</a></h1>'
+
+    # Widget: source link
+    source_link = ''
+    if cfg['source_link']['visible']:
+        sl = cfg['source_link']
+        source_link = f'<a href="{_escape(sl["url"])}" class="gh-link" target="_blank" rel="noopener">{_escape(sl["text"])}</a>'
+
+    # Widget: dark mode toggle
+    toggle = ''
+    if cfg['dark_mode_toggle']['visible']:
+        toggle = '<button id="theme-toggle" aria-label="Toggle theme">🌚</button>'
+
+    # Widget: calendar toggle button (mobile)
+    cal_toggle = ''
+    cal_sidebar = ''
+    cal_modal = ''
+    if cfg['calendar']['visible']:
+        cal_toggle = '<button id="cal-toggle" class="cal-toggle">Cal</button>'
+        cal_sidebar = render_calendar_sidebar()
+        cal_modal = '''<div id="cal-modal" class="cal-modal-overlay" hidden>
+  <div class="cal-modal-box">
+    <div class="cal-modal-header">
+      <span class="cal-modal-title">Calendar</span>
+      <button id="cal-modal-close" class="cal-modal-close">&times;</button>
+    </div>
+    <div id="cal-modal-body"></div>
+  </div>
+</div>'''
+
+    # Widget: description
+    desc = ''
+    if cfg['description']['visible']:
+        desc_text = cfg['description']['text']
+        desc_text = desc_text.replace('{count}', f'<span class="post-count">{total}</span>').replace('{handle}', HANDLE)
+        desc = f'<section class="intro"><p>{desc_text}</p></section>'
+
     return f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -173,25 +297,23 @@ def generate_html(days, known_ids, total):
 <title>Chronobsky Archive</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+{font_link}
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <header>
   <div class="header-inner">
-    <h1><a href="#">Chronobsky</a></h1>
+    {logo}
     <nav>
-      <a href="https://github.com/toxdes/chronobsky" class="gh-link" target="_blank" rel="noopener">Source</a>
-      <button id="cal-toggle" class="cal-toggle">Cal</button>
-      <button id="theme-toggle" aria-label="Toggle theme">🌚</button>
+      {source_link}
+      {cal_toggle}
+      {toggle}
     </nav>
   </div>
 </header>
 <div class="page-wrap">
 <main>
-<section class="intro">
-  <p><span class="post-count">{total} posts</span> from <a href="https://bsky.app/profile/{_escape(HANDLE)}" target="_blank" rel="noopener">@{_escape(HANDLE)}</a> on bsky.social</p>
-</section>
+{desc}
 {sections}
 </main>
 {cal_sidebar}
@@ -200,15 +322,7 @@ def generate_html(days, known_ids, total):
   <button id="modal-close" class="modal-close">&times;</button>
   <img id="modal-img" src="" alt="">
 </div>
-<div id="cal-modal" class="cal-modal-overlay" hidden>
-  <div class="cal-modal-box">
-    <div class="cal-modal-header">
-      <span class="cal-modal-title">Calendar</span>
-      <button id="cal-modal-close" class="cal-modal-close">&times;</button>
-    </div>
-    <div id="cal-modal-body"></div>
-  </div>
-</div>
+{cal_modal}
 <script>
 var ACTIVE_DATES = {dates_json};
 </script>
@@ -219,30 +333,23 @@ var ACTIVE_DATES = {dates_json};
 
 # ── Static assets ───────────────────────────────────────────────
 
-STYLE_CSS = r'''/* ── Variables ────────────────────────────────────── */
-:root {
-  --bg: #ffffff;
-  --text: #0f172a;
-  --border: #e2e8f0;
-  --accent: #2563eb;
-  --muted: #64748b;
-  --reply: #f1f5f9;
-  --header: rgba(255, 255, 255, 0.85);
-  --link-icon: #cbd5e1;
-}
+def _theme_vars(cfg):
+    t = cfg['theme']
+    out = ['/* ── Variables ────────────────────────────────────── */',
+           ':root {']
+    for k, v in t['light'].items():
+        out.append(f'  --{k.replace("_", "-")}: {v};')
+    out.append('}')
+    out.append('')
+    out.append(':root.dark {')
+    for k, v in t['dark'].items():
+        out.append(f'  --{k.replace("_", "-")}: {v};')
+    out.append('}')
+    return '\n'.join(out)
 
-:root.dark {
-  --bg: #0f172a;
-  --text: #e2e8f0;
-  --border: #1e293b;
-  --accent: #60a5fa;
-  --muted: #94a3b8;
-  --reply: #1e293b;
-  --header: rgba(15, 23, 42, 0.85);
-  --link-icon: #475569;
-}
 
-/* ── Reset ──────────────────────────────────────── */
+def _reset_css():
+    return '''/* ── Reset ──────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html { scroll-behavior: smooth; }
 
@@ -254,407 +361,251 @@ body {
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
   transition: background .3s, color .3s;
-}
+}'''
 
-/* ── Header ─────────────────────────────────────── */
+
+def _header_css():
+    return '''/* ── Header ─────────────────────────────────────── */
 header {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  background: var(--header);
+  position: sticky; top: 0; z-index: 100;
+  background: var(--header-bg);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
   transition: background .3s, border-color .3s;
 }
-
 .header-inner {
-  max-width: 980px;
-  margin: 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  max-width: 980px; margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between;
   padding: 12px 24px;
 }
-
 header h1 { font-size: 18px; font-weight: 600; letter-spacing: -.01em; }
 header h1 a { color: var(--text); text-decoration: none; }
-
 header nav { display: flex; align-items: center; gap: 12px; }
-
 .gh-link {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--muted);
-  text-decoration: none;
-  transition: color .2s;
+  font-size: 13px; font-weight: 500; color: var(--muted);
+  text-decoration: none; transition: color .2s;
 }
 .gh-link:hover { color: var(--accent); }
-
-.cal-toggle {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  color: var(--muted);
-  line-height: 1;
-  transition: color .2s, border-color .2s;
-  display: none;
-}
-.cal-toggle:hover { color: var(--accent); border-color: var(--accent); }
-
 #theme-toggle {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 18px;
-  cursor: pointer;
-  line-height: 1;
+  background: none; border: 1px solid var(--border); border-radius: 8px;
+  padding: 6px 10px; font-size: 18px; cursor: pointer; line-height: 1;
   transition: border-color .2s;
 }
-#theme-toggle:hover { border-color: var(--accent); }
+#theme-toggle:hover { border-color: var(--accent); }'''
 
-/* ── Page layout ──────────────────────────────────── */
-.page-wrap {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 40px 24px 80px;
-  display: flex;
-  gap: 40px;
-  align-items: flex-start;
-}
 
-main {
-  flex: 0 0 680px;
-  max-width: 680px;
-}
-
-.intro {
-  margin-bottom: 40px;
-  padding-bottom: 24px;
-  border-bottom: 1px solid var(--border);
-  font-size: 14px;
-  color: var(--muted);
-  line-height: 1.6;
-  transition: border-color .3s;
-}
-
-.intro a {
-  color: var(--accent);
-  text-decoration: none;
-  font-weight: 500;
-}
-.intro a:hover { text-decoration: underline; }
-
-.post-count {
-  font-weight: 500;
-  color: var(--text);
-}
-
-/* ── Calendar sidebar ────────────────────────────── */
-.cal-sidebar {
-  flex: 0 0 220px;
-  position: sticky;
-  top: 70px;
-}
-
-#calendar {
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 12px;
-  overflow: hidden;
-  transition: border-color .3s;
-}
-
-.cal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 10px;
-}
-
-.cal-label {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.cal-nav {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0 8px;
-  font-size: 14px;
-  cursor: pointer;
-  color: var(--muted);
-  line-height: 1;
-  height: 26px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+def _cal_toggle_css():
+    return '''.cal-toggle {
+  background: none; border: 1px solid var(--border); border-radius: 8px;
+  padding: 6px 10px; font-size: 13px; font-weight: 500; cursor: pointer;
+  color: var(--muted); line-height: 1; display: none;
   transition: color .2s, border-color .2s;
 }
-.cal-nav:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-.cal-nav:disabled {
-  opacity: 0.25;
-  cursor: default;
-  pointer-events: none;
-}
+.cal-toggle:hover { color: var(--accent); border-color: var(--accent); }'''
 
-.cal-grid {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 12px;
-}
 
-.cal-grid th {
-  font-weight: 500;
-  color: var(--muted);
-  padding: 2px 0;
-  text-align: center;
-  font-size: 11px;
+def _layout_css():
+    return '''/* ── Page layout ──────────────────────────────────── */
+.page-wrap {
+  max-width: 980px; margin: 0 auto; padding: 40px 24px 80px;
+  display: flex; gap: 40px; align-items: flex-start;
 }
-
-.cal-grid td {
-  text-align: center;
-  padding: 3px 0;
-  color: var(--muted);
-  font-size: 12px;
+main { flex: 0 0 680px; max-width: 680px; }
+.intro {
+  margin-bottom: 40px; padding-bottom: 24px;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px; color: var(--muted); line-height: 1.6;
+  transition: border-color .3s;
 }
+.intro a { color: var(--accent); text-decoration: none; font-weight: 500; }
+.intro a:hover { text-decoration: underline; }
+.post-count { font-weight: 500; color: var(--text); }'''
 
-.cal-grid td a {
-  display: inline-block;
-  width: 24px;
-  height: 24px;
-  line-height: 24px;
-  border-radius: 50%;
-  text-decoration: none;
-  color: var(--text);
-  font-weight: 500;
-  font-size: 12px;
-  transition: background .2s, color .2s;
-}
 
-.cal-grid td a:hover {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--accent);
-}
-
-.cal-grid td a.active {
-  color: var(--accent);
-  font-weight: 600;
-}
-
-/* ── Day section ────────────────────────────────── */
+def _day_css():
+    return '''/* ── Day section ────────────────────────────────── */
 .day { margin-bottom: 48px; scroll-margin-top: 80px; }
 .day h2 {
-  font-size: 20px;
-  font-weight: 600;
-  color: var(--accent);
-  margin-bottom: 24px;
-  padding-bottom: 8px;
+  font-size: 20px; font-weight: 600; color: var(--accent);
+  margin-bottom: 24px; padding-bottom: 8px;
   border-bottom: 2px solid var(--border);
   transition: color .3s, border-color .3s;
-}
+}'''
 
-/* ── Post card ──────────────────────────────────── */
+
+def _post_css():
+    return '''/* ── Post card ──────────────────────────────────── */
 .post {
-  margin-bottom: 16px;
-  padding: 16px 20px;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  scroll-margin-top: 70px;
+  margin-bottom: 16px; padding: 16px 20px; border-radius: 12px;
+  border: 1px solid var(--border); scroll-margin-top: 70px;
   transition: border-color .3s, background .3s;
 }
-.post.reply { background: var(--reply); }
-
+.post.reply { background: var(--reply-bg); }
 .post-meta {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
-  font-size: 13px;
-  color: var(--muted);
+  display: flex; align-items: center; gap: 6px;
+  margin-bottom: 8px; font-size: 13px; color: var(--muted);
 }
 .post-meta time { font-weight: 500; }
-
 .reply-badge {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--accent);
-  padding: 1px 6px;
-  border-radius: 4px;
+  font-size: 11px; font-weight: 600; color: var(--accent);
+  padding: 1px 6px; border-radius: 4px;
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
-
-a.reply-badge {
-  text-decoration: none;
-  transition: background .2s;
-}
-a.reply-badge:hover {
-  background: color-mix(in srgb, var(--accent) 20%, transparent);
-}
-
+a.reply-badge { text-decoration: none; transition: background .2s; }
+a.reply-badge:hover { background: color-mix(in srgb, var(--accent) 20%, transparent); }
 .post-link {
-  margin-left: auto;
-  color: var(--link-icon);
-  text-decoration: none;
-  font-size: 12px;
-  opacity: 0;
-  transition: opacity .2s;
+  margin-left: auto; color: var(--link-icon); text-decoration: none;
+  font-size: 12px; opacity: 0; transition: opacity .2s;
 }
 .post:hover .post-link { opacity: 1; }
 .post-link:hover { color: var(--accent); }
-
 .quote-link {
-  display: inline-block;
-  margin-top: 10px;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--accent);
-  text-decoration: none;
-  padding: 3px 10px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
+  display: inline-block; margin-top: 10px; font-size: 13px; font-weight: 500;
+  color: var(--accent); text-decoration: none; padding: 3px 10px;
+  border-radius: 6px; border: 1px solid var(--border);
   transition: background .2s, border-color .2s;
 }
 .quote-link:hover {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
   border-color: var(--accent);
-}
+}'''
 
-/* ── Content ────────────────────────────────────── */
+
+def _content_css():
+    return '''/* ── Content ────────────────────────────────────── */
 .post-content {
-  font-size: 15px;
-  line-height: 1.7;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
+  font-size: 15px; line-height: 1.7;
+  word-wrap: break-word; overflow-wrap: break-word;
 }
 .post-content p { margin-bottom: 8px; }
 .post-content p:last-child { margin-bottom: 0; }
-.post-content a {
-  color: var(--accent);
-  word-break: break-all;
-}
+.post-content a { color: var(--accent); word-break: break-all; }'''
 
-/* ── Images ─────────────────────────────────────── */
-.post-images {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 12px;
-}
+
+def _image_css():
+    return '''/* ── Images ─────────────────────────────────────── */
+.post-images { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
 .post-images img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 8px;
+  max-width: 100%; height: auto; border-radius: 8px;
   border: 1px solid var(--border);
-}
+}'''
 
-/* ── Calendar modal (mobile) ────────────────────── */
+
+def _calendar_sidebar_css():
+    return '''/* ── Calendar sidebar ────────────────────────────── */
+.cal-sidebar { flex: 0 0 220px; position: sticky; top: 70px; }
+#calendar {
+  border: 1px solid var(--border); border-radius: 10px;
+  padding: 12px; overflow: hidden; transition: border-color .3s;
+}
+.cal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.cal-label { font-size: 13px; font-weight: 600; color: var(--text); }
+.cal-nav {
+  background: none; border: 1px solid var(--border); border-radius: 6px;
+  padding: 0 8px; font-size: 14px; cursor: pointer; color: var(--muted);
+  line-height: 1; height: 26px;
+  display: flex; align-items: center; justify-content: center;
+  transition: color .2s, border-color .2s;
+}
+.cal-nav:hover { color: var(--accent); border-color: var(--accent); }
+.cal-nav:disabled { opacity: 0.25; cursor: default; pointer-events: none; }
+.cal-grid { width: 100%; border-collapse: collapse; font-size: 12px; }
+.cal-grid th { font-weight: 500; color: var(--muted); padding: 2px 0; text-align: center; font-size: 11px; }
+.cal-grid td { text-align: center; padding: 3px 0; color: var(--muted); font-size: 12px; }
+.cal-grid td a {
+  display: inline-block; width: 24px; height: 24px; line-height: 24px;
+  border-radius: 50%; text-decoration: none; color: var(--text);
+  font-weight: 500; font-size: 12px; transition: background .2s, color .2s;
+}
+.cal-grid td a:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); color: var(--accent); }
+.cal-grid td a.active { color: var(--accent); font-weight: 600; }'''
+
+
+def _cal_modal_css():
+    return '''/* ── Calendar modal (mobile) ────────────────────── */
 .cal-modal-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 200;
+  position: fixed; inset: 0; z-index: 200;
   background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
+  display: flex; align-items: center; justify-content: center; cursor: pointer;
 }
 .cal-modal-overlay[hidden] { display: none; }
-
 .cal-modal-box {
-  background: var(--bg);
-  border-radius: 14px;
-  padding: 20px;
-  width: 300px;
-  cursor: default;
-  transition: background .3s;
+  background: var(--bg); border-radius: 14px; padding: 20px;
+  width: 300px; cursor: default; transition: background .3s;
 }
-
-.cal-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-
-.cal-modal-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-}
-
+.cal-modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+.cal-modal-title { font-size: 15px; font-weight: 600; color: var(--text); }
 .cal-modal-close {
-  background: none;
-  border: none;
-  font-size: 22px;
-  cursor: pointer;
-  color: var(--muted);
-  padding: 0;
-  line-height: 1;
+  background: none; border: none; font-size: 22px; cursor: pointer;
+  color: var(--muted); padding: 0; line-height: 1;
 }
-.cal-modal-close:hover { color: var(--text); }
+.cal-modal-close:hover { color: var(--text); }'''
 
-/* ── Responsive ─────────────────────────────────── */
-@media (max-width: 800px) {
-  .cal-sidebar { display: none; }
-  .cal-toggle { display: inline-flex; align-items: center; }
-  .page-wrap { padding: 24px 16px 60px; }
-  main { flex: none; max-width: none; }
-  .page-wrap { display: block; }
-  .post { padding: 12px 14px; }
-  .post-content { font-size: 14px; }
-  .day h2 { font-size: 18px; }
-}
 
-/* ── Print ──────────────────────────────────────── */
-@media print { header, .post-link, .cal-sidebar, .cal-toggle { display: none; } }
-
-/* ── Image lightbox ─────────────────────────────── */
+def _lightbox_css():
+    return '''/* ── Image lightbox ─────────────────────────────── */
 .modal-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 200;
+  position: fixed; inset: 0; z-index: 200;
   background: rgba(0, 0, 0, 0.85);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
+  display: flex; align-items: center; justify-content: center; cursor: pointer;
 }
 .modal-overlay[hidden] { display: none; }
-.modal-overlay img {
-  max-width: 90vw;
-  max-height: 90vh;
-  object-fit: contain;
-  border-radius: 4px;
-  cursor: default;
-}
+.modal-overlay img { max-width: 90vw; max-height: 90vh; object-fit: contain; border-radius: 4px; cursor: default; }
 .modal-close {
-  position: fixed;
-  top: 16px;
-  right: 16px;
-  background: none;
-  border: none;
-  font-size: 32px;
-  color: #fff;
-  cursor: pointer;
-  opacity: 0.6;
-  z-index: 201;
-  line-height: 1;
+  position: fixed; top: 16px; right: 16px;
+  background: none; border: none; font-size: 32px; color: #fff;
+  cursor: pointer; opacity: 0.6; z-index: 201; line-height: 1;
   transition: opacity .2s;
 }
-.modal-close:hover { opacity: 1; }
-'''
+.modal-close:hover { opacity: 1; }'''
 
-THEME_JS = r'''(function() {
+
+def _responsive_css(cal_visible):
+    parts = ['/* ── Responsive ─────────────────────────────────── */',
+             '@media (max-width: 800px) {']
+    if cal_visible:
+        parts.append('  .cal-sidebar { display: none; }')
+        parts.append('  .cal-toggle { display: inline-flex; align-items: center; }')
+    parts.extend([
+        '  .page-wrap { padding: 24px 16px 60px; }',
+        '  main { flex: none; max-width: none; }',
+        '  .page-wrap { display: block; }',
+        '  .post { padding: 12px 14px; }',
+        '  .post-content { font-size: 14px; }',
+        '  .day h2 { font-size: 18px; }',
+        '}',
+    ])
+    return '\n'.join(parts)
+
+
+def _print_css(cal_visible):
+    hide = 'header, .post-link'
+    if cal_visible:
+        hide += ', .cal-sidebar, .cal-toggle'
+    return f'/* ── Print ──────────────────────────────────────── */\n@media print {{ {hide} {{ display: none; }} }}'
+
+
+def generate_style_css(cfg):
+    parts = [
+        _theme_vars(cfg),
+        _reset_css(),
+        _header_css(),
+        _layout_css(),
+        _day_css(),
+        _post_css(),
+        _content_css(),
+        _image_css(),
+    ]
+    if cfg['calendar']['visible']:
+        parts.append(_cal_toggle_css())
+        parts.append(_calendar_sidebar_css())
+        parts.append(_cal_modal_css())
+    parts.append(_lightbox_css())
+    parts.append(_responsive_css(cfg['calendar']['visible']))
+    parts.append(_print_css(cfg['calendar']['visible']))
+    return '\n\n'.join(parts) + '\n'
+
+THEME_TOGGLE_JS = '''(function() {
   var key = 'theme';
   var stored = localStorage.getItem(key);
   var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -667,17 +618,13 @@ THEME_JS = r'''(function() {
     document.documentElement.classList.toggle('dark');
     var isDark = document.documentElement.classList.contains('dark');
     localStorage.setItem(key, isDark ? 'dark' : 'light');
-    this.textContent = isDark ? '😎' : '🌚';
+    this.textContent = isDark ? '\U0001f60e' : '\U0001f31a';
   });
-})();
+})();'''
 
-(function() {
+
+CALENDAR_JS = '''(function() {
   var dates = typeof ACTIVE_DATES !== 'undefined' ? ACTIVE_DATES : [];
-  var active = {};
-  dates.forEach(function(d) { active[d] = true; });
-
-  function pad(n) { return n < 10 ? '0' + n : '' + n; }
-
   var months = {};
   dates.forEach(function(d) {
     var p = d.split('-');
@@ -688,9 +635,8 @@ THEME_JS = r'''(function() {
 
   var sortedMonths = Object.keys(months).sort();
   var today = new Date();
-  var firstKey = sortedMonths.length ? sortedMonths[0] : null;
   var lastKey = sortedMonths.length ? sortedMonths[sortedMonths.length - 1] : null;
-  var curKey = lastKey || (today.getFullYear() + '-' + pad(today.getMonth() + 1));
+  var curKey = lastKey || (today.getFullYear() + '-' + (today.getMonth() < 9 ? '0' : '') + (today.getMonth() + 1));
   var curParts = curKey.split('-');
   var curYear = parseInt(curParts[0], 10);
   var curMonth = parseInt(curParts[1], 10);
@@ -700,11 +646,19 @@ THEME_JS = r'''(function() {
   var prevBtn = document.getElementById('cal-prev');
   var nextBtn = document.getElementById('cal-next');
 
+  function pad(n) { return n < 10 ? '0' + n : '' + n; }
+  function adjKey(year, month, delta) {
+    var m = month + delta;
+    var y = year;
+    if (m < 1) { m = 12; y--; }
+    if (m > 12) { m = 1; y++; }
+    return y + '-' + pad(m);
+  }
+
   function render(year, month) {
     var first = new Date(year, month - 1, 1);
-    var last = new Date(year, month, 0);
     var startDay = (first.getDay() + 6) % 7;
-    var daysInMonth = last.getDate();
+    var daysInMonth = new Date(year, month, 0).getDate();
     var now = new Date();
     var isCurrentMonth = year === now.getFullYear() && month === now.getMonth() + 1;
     var todayDate = now.getDate();
@@ -719,50 +673,31 @@ THEME_JS = r'''(function() {
     activeDays.forEach(function(d) { activeSet[d] = true; });
 
     var html = '<tr>';
-    for (var i = 0; i < startDay; i++) {
-      html += '<td></td>';
-    }
+    for (var i = 0; i < startDay; i++) html += '<td></td>';
     for (var day = 1; day <= daysInMonth; day++) {
       var idx = startDay + day - 1;
       if (idx > 0 && idx % 7 === 0) html += '</tr><tr>';
-      var isActive = activeSet[day] || false;
-      var isToday = isCurrentMonth && day === todayDate;
-      if (isActive) {
-        var dateStr = year + '-' + pad(month) + '-' + pad(day);
-        html += '<td><a href="#' + dateStr + '" class="active">' + day + '</a></td>';
+      if (activeSet[day]) {
+        html += '<td><a href="#' + year + '-' + pad(month) + '-' + pad(day) + '" class="active">' + day + '</a></td>';
       } else {
-        html += '<td' + (isToday ? ' style="font-weight:600"' : '') + '>' + day + '</td>';
+        html += '<td' + (isCurrentMonth && day === todayDate ? ' style="font-weight:600"' : '') + '>' + day + '</td>';
       }
     }
     html += '</tr>';
     body.innerHTML = html;
-
-    prevBtn.disabled = !months[_adjKey(year, month, -1)];
-    nextBtn.disabled = !months[_adjKey(year, month, 1)];
+    prevBtn.disabled = !months[adjKey(year, month, -1)];
+    nextBtn.disabled = !months[adjKey(year, month, 1)];
   }
 
-  function _adjKey(year, month, delta) {
-    var m = month + delta;
-    var y = year;
-    if (m < 1) { m = 12; y--; }
-    if (m > 12) { m = 1; y++; }
-    return y + '-' + pad(m);
-  }
-
-  function goTo(delta) {
-    curMonth += delta;
-    if (curMonth < 1) { curMonth = 12; curYear--; }
-    if (curMonth > 12) { curMonth = 1; curYear++; }
-    render(curYear, curMonth);
-  }
+  function goTo(d) { curMonth += d; if (curMonth < 1) { curMonth = 12; curYear--; } if (curMonth > 12) { curMonth = 1; curYear++; } render(curYear, curMonth); }
 
   if (prevBtn) prevBtn.addEventListener('click', function() { goTo(-1); });
   if (nextBtn) nextBtn.addEventListener('click', function() { goTo(1); });
-
   render(curYear, curMonth);
-})();
+})();'''
 
-(function() {
+
+LIGHTBOX_JS = '''(function() {
   var modal = document.getElementById('image-modal');
   var modalImg = document.getElementById('modal-img');
   var modalClose = document.getElementById('modal-close');
@@ -774,10 +709,7 @@ THEME_JS = r'''(function() {
     }
   });
 
-  function close() {
-    modal.setAttribute('hidden', '');
-    modalImg.src = '';
-  }
+  function close() { modal.setAttribute('hidden', ''); modalImg.src = ''; }
 
   modal.addEventListener('click', function(e) {
     if (e.target === modal || e.target === modalClose) close();
@@ -786,14 +718,14 @@ THEME_JS = r'''(function() {
   document.addEventListener('keydown', function(e) {
     if (e.key === 'Escape' && !modal.hasAttribute('hidden')) close();
   });
-})();
+})();'''
 
-(function() {
+
+CALENDAR_MODAL_JS = '''(function() {
   var calModal = document.getElementById('cal-modal');
   var calBody = document.getElementById('cal-modal-body');
   var calToggle = document.getElementById('cal-toggle');
   var calClose = document.getElementById('cal-modal-close');
-
   if (!calToggle || !calModal) return;
 
   function openCal() {
@@ -803,28 +735,33 @@ THEME_JS = r'''(function() {
     calBody.innerHTML = '';
     calBody.appendChild(clone);
     calModal.removeAttribute('hidden');
-
     clone.querySelectorAll('a[href^="#"]').forEach(function(a) {
-      a.addEventListener('click', function() {
-        calModal.setAttribute('hidden', '');
-      });
+      a.addEventListener('click', function() { calModal.setAttribute('hidden', ''); });
     });
   }
 
   calToggle.addEventListener('click', openCal);
-
   calModal.addEventListener('click', function(e) {
-    if (e.target === calModal || e.target === calClose) {
-      calModal.setAttribute('hidden', '');
-    }
+    if (e.target === calModal || e.target === calClose) calModal.setAttribute('hidden', '');
   });
-})();
-'''
+})();'''
+
+
+def generate_theme_js(cfg):
+    parts = []
+    if cfg['dark_mode_toggle']['visible']:
+        parts.append(THEME_TOGGLE_JS)
+    if cfg['calendar']['visible']:
+        parts.append(CALENDAR_JS)
+        parts.append(CALENDAR_MODAL_JS)
+    parts.append(LIGHTBOX_JS)
+    return '\n\n'.join(parts) + '\n'
 
 
 # ── Main ────────────────────────────────────────────────────────
 
 def main():
+    cfg = _load_config()
     posts = load_all_posts()
     if not posts:
         print('No posts found in tweets/.')
@@ -838,13 +775,13 @@ def main():
     os.makedirs(DIST_DIR, exist_ok=True)
 
     with open(os.path.join(DIST_DIR, 'index.html'), 'w') as f:
-        f.write(generate_html(days, known_ids, total))
+        f.write(generate_html(days, known_ids, total, cfg))
 
     with open(os.path.join(DIST_DIR, 'style.css'), 'w') as f:
-        f.write(STYLE_CSS)
+        f.write(generate_style_css(cfg))
 
     with open(os.path.join(DIST_DIR, 'theme.js'), 'w') as f:
-        f.write(THEME_JS)
+        f.write(generate_theme_js(cfg))
 
     print(f'Generated dist/ — {len(days)} days, {total} posts.')
 

--- a/gen.py
+++ b/gen.py
@@ -33,32 +33,32 @@ HANDLE = _load_dotenv(_ENV_PATH).get('BLUESKY_HANDLE', 'yourhandle.bsky.social')
 # ── Config ────────────────────────────────────────────────────────
 
 DEFAULT_CONFIG = {
-    "version": 1,
+    "version": 2,
     "font": {
         "family": "Inter",
         "weights": [400, 500, 600],
         "source": "google",
         "url": None,
     },
-    "logo": {
-        "visible": True,
-        "text": "Chronobsky",
-        "url": "#",
+    "layout": {
+        "header": ["logo", "source_link", "dark_mode_toggle"],
+        "sidebar": ["calendar"],
+        "content": ["description"],
     },
-    "description": {
-        "visible": True,
-        "text": "{count} posts from @{handle} on bsky.social",
-    },
-    "source_link": {
-        "visible": True,
-        "text": "Source",
-        "url": "https://github.com/toxdes/chronobsky",
-    },
-    "dark_mode_toggle": {
-        "visible": True,
-    },
-    "calendar": {
-        "visible": True,
+    "widgets": {
+        "logo": {
+            "text": "Chronobsky",
+            "url": "#",
+        },
+        "source_link": {
+            "text": "Source",
+            "url": "https://github.com/toxdes/chronobsky",
+        },
+        "dark_mode_toggle": {},
+        "calendar": {},
+        "description": {
+            "text": "{count} posts from @{handle} on bsky.social",
+        },
     },
     "theme": {
         "light": {
@@ -106,8 +106,8 @@ def _load_config(path=None):
     with open(path) as f:
         overrides = json.load(f)
     cfg = _deep_merge(DEFAULT_CONFIG, overrides)
-    if cfg.get('version', 1) > 1:
-        print(f'Warning: config version {cfg["version"]} is newer than generator version 1')
+    if cfg.get('version', 2) > 2:
+        print(f'Warning: config version {cfg["version"]} is newer than generator version 2')
     return cfg
 
 
@@ -242,6 +242,18 @@ def render_calendar_sidebar():
 </aside>'''
 
 
+def render_calendar_modal():
+    return '''<div id="cal-modal" class="cal-modal-overlay" hidden>
+  <div class="cal-modal-box">
+    <div class="cal-modal-header">
+      <span class="cal-modal-title">Calendar</span>
+      <button id="cal-modal-close" class="cal-modal-close">&times;</button>
+    </div>
+    <div id="cal-modal-body"></div>
+  </div>
+</div>'''
+
+
 def _render_font_link(cfg):
     font = cfg['font']
     if font['source'] == 'google':
@@ -253,51 +265,81 @@ def _render_font_link(cfg):
     return ''
 
 
+def _nav_item_html(name, cfg):
+    w = cfg['widgets']
+    if name == 'source_link':
+        sl = w['source_link']
+        return f'<a href="{_escape(sl["url"])}" class="gh-link" target="_blank" rel="noopener">{_escape(sl["text"])}</a>'
+    if name == 'dark_mode_toggle':
+        return '<button id="theme-toggle" aria-label="Toggle theme">🌚</button>'
+    if name == 'calendar':
+        return '<button id="cal-toggle" class="cal-toggle">Cal</button>'
+    return ''
+
+
+def _sidebar_html(name, cfg):
+    if name == 'calendar':
+        return render_calendar_sidebar()
+    return ''
+
+
+def _content_html(name, cfg, total):
+    if name == 'description':
+        desc_text = cfg['widgets']['description'].get('text', '')
+        desc_text = desc_text.replace('{count}', f'<span class="post-count">{total}</span>').replace('{handle}', HANDLE)
+        return f'<section class="intro"><p>{desc_text}</p></section>'
+    return ''
+
+
 def generate_html(days, known_ids, total, cfg):
     sections = '\n'.join(render_day(d, ps, known_ids) for d, ps in days.items())
     dates_json = json.dumps(sorted(days.keys()))
     font_link = _render_font_link(cfg)
+    layout = cfg['layout']
+    w = cfg['widgets']
 
-    # Widget: logo
+    # Logo (special: outside <nav>)
     logo = ''
-    if cfg['logo']['visible']:
-        logo = f'<h1><a href="{_escape(cfg["logo"]["url"])}">{_escape(cfg["logo"]["text"])}</a></h1>'
+    if 'logo' in layout.get('header', []) and 'logo' in w:
+        l = w['logo']
+        logo = f'<h1><a href="{_escape(l["url"])}">{_escape(l["text"])}</a></h1>'
 
-    # Widget: source link
-    source_link = ''
-    if cfg['source_link']['visible']:
-        sl = cfg['source_link']
-        source_link = f'<a href="{_escape(sl["url"])}" class="gh-link" target="_blank" rel="noopener">{_escape(sl["text"])}</a>'
+    # Header nav items
+    nav_items = []
+    has_calendar = any('calendar' in layout.get(slot, []) for slot in layout)
+    for name in layout.get('header', []):
+        if name == 'logo':
+            continue
+        html = _nav_item_html(name, cfg)
+        if html:
+            nav_items.append(html)
+    if has_calendar:
+        nav_items.append(_nav_item_html('calendar', cfg))
+    nav_html = '\n      '.join(nav_items)
 
-    # Widget: dark mode toggle
-    toggle = ''
-    if cfg['dark_mode_toggle']['visible']:
-        toggle = '<button id="theme-toggle" aria-label="Toggle theme">🌚</button>'
+    # Sidebar
+    sidebar_html = ''
+    for name in layout.get('sidebar', []):
+        html = _sidebar_html(name, cfg)
+        if html:
+            sidebar_html += html
 
-    # Widget: calendar toggle button (mobile)
-    cal_toggle = ''
-    cal_sidebar = ''
-    cal_modal = ''
-    if cfg['calendar']['visible']:
-        cal_toggle = '<button id="cal-toggle" class="cal-toggle">Cal</button>'
-        cal_sidebar = render_calendar_sidebar()
-        cal_modal = '''<div id="cal-modal" class="cal-modal-overlay" hidden>
-  <div class="cal-modal-box">
-    <div class="cal-modal-header">
-      <span class="cal-modal-title">Calendar</span>
-      <button id="cal-modal-close" class="cal-modal-close">&times;</button>
-    </div>
-    <div id="cal-modal-body"></div>
-  </div>
+    # Content above posts
+    content_top = ''
+    for name in layout.get('content', []):
+        html = _content_html(name, cfg, total)
+        if html:
+            content_top += html
+
+    # Modals
+    modals = '''<div id="image-modal" class="modal-overlay" hidden>
+  <button id="modal-close" class="modal-close">&times;</button>
+  <img id="modal-img" src="" alt="">
 </div>'''
+    if sidebar_html:
+        modals += render_calendar_modal()
 
-    # Widget: description
-    desc = ''
-    if cfg['description']['visible']:
-        desc_text = cfg['description']['text']
-        desc_text = desc_text.replace('{count}', f'<span class="post-count">{total}</span>').replace('{handle}', HANDLE)
-        desc = f'<section class="intro"><p>{desc_text}</p></section>'
-
+    content_wrap = 'page-wrap' if sidebar_html else ''
     return f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -314,24 +356,18 @@ def generate_html(days, known_ids, total, cfg):
   <div class="header-inner">
     {logo}
     <nav>
-      {source_link}
-      {cal_toggle}
-      {toggle}
+      {nav_html}
     </nav>
   </div>
 </header>
-<div class="page-wrap">
+<div class="{content_wrap}">
 <main>
-{desc}
+{content_top}
 {sections}
 </main>
-{cal_sidebar}
+{sidebar_html}
 </div>
-<div id="image-modal" class="modal-overlay" hidden>
-  <button id="modal-close" class="modal-close">&times;</button>
-  <img id="modal-img" src="" alt="">
-</div>
-{cal_modal}
+{modals}
 <script>
 var ACTIVE_DATES = {dates_json};
 </script>
@@ -367,7 +403,7 @@ body {{
   background: var(--bg);
   color: var(--text);
   line-height: 1.7;
-  font-size: 16px;
+  font-size: 1rem;
   -webkit-font-smoothing: antialiased;
   transition: background .3s, color .3s;
 }}'''
@@ -378,26 +414,26 @@ def _header_css():
 header {
   position: sticky; top: 0; z-index: 100;
   background: var(--header-bg);
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(0.75rem);
   border-bottom: 1px solid var(--border);
   transition: background .3s, border-color .3s;
 }
 .header-inner {
   max-width: 980px; margin: 0 auto;
   display: flex; align-items: center; justify-content: space-between;
-  padding: 12px 24px;
+  padding: 0.75rem 1.5rem;
 }
-header h1 { font-size: 18px; font-weight: 600; letter-spacing: -.01em; }
+header h1 { font-size: 1.125rem; font-weight: 600; letter-spacing: -.01em; }
 header h1 a { color: var(--text); text-decoration: none; }
-header nav { display: flex; align-items: center; gap: 12px; }
+header nav { display: flex; align-items: center; gap: 0.75rem; }
 .gh-link {
-  font-size: 13px; font-weight: 500; color: var(--muted);
+  font-size: 0.8125rem; font-weight: 500; color: var(--muted);
   text-decoration: none; transition: color .2s;
 }
 .gh-link:hover { color: var(--accent); }
 #theme-toggle {
-  background: none; border: 1px solid var(--border); border-radius: 8px;
-  padding: 6px 10px; font-size: 18px; cursor: pointer; line-height: 1;
+  background: none; border: 1px solid var(--border); border-radius: 0.5rem;
+  padding: 0.375rem 0.625rem; font-size: 1.125rem; cursor: pointer; line-height: 1;
   transition: border-color .2s;
 }
 #theme-toggle:hover { border-color: var(--accent); }'''
@@ -405,73 +441,70 @@ header nav { display: flex; align-items: center; gap: 12px; }
 
 def _cal_toggle_css():
     return '''.cal-toggle {
-  background: none; border: 1px solid var(--border); border-radius: 8px;
-  padding: 6px 10px; font-size: 13px; font-weight: 500; cursor: pointer;
+  background: none; border: 1px solid var(--border); border-radius: 0.5rem;
+  padding: 0.375rem 0.625rem; font-size: 0.8125rem; font-weight: 500; cursor: pointer;
   color: var(--muted); line-height: 1; display: none;
   transition: color .2s, border-color .2s;
 }
 .cal-toggle:hover { color: var(--accent); border-color: var(--accent); }'''
 
-
 def _layout_css():
     return '''/* ── Page layout ──────────────────────────────────── */
 .page-wrap {
-  max-width: 980px; margin: 0 auto; padding: 40px 24px 80px;
-  display: flex; gap: 40px; align-items: flex-start;
+  max-width: 980px; margin: 0 auto; padding: 2.5rem 1.5rem 5rem;
+  display: flex; gap: 2.5rem; align-items: flex-start;
 }
 main { flex: 0 0 680px; max-width: 680px; }
 .intro {
-  margin-bottom: 40px; padding-bottom: 24px;
+  margin-bottom: 2.5rem; padding-bottom: 1.5rem;
   border-bottom: 1px solid var(--border);
-  font-size: 14px; color: var(--muted); line-height: 1.6;
+  font-size: 0.875rem; color: var(--muted); line-height: 1.6;
   transition: border-color .3s;
 }
 .intro a { color: var(--accent); text-decoration: none; font-weight: 500; }
 .intro a:hover { text-decoration: underline; }
 .post-count { font-weight: 500; color: var(--text); }'''
 
-
 def _day_css():
     return '''/* ── Day section ────────────────────────────────── */
-.day { margin-bottom: 48px; scroll-margin-top: 80px; }
+.day { margin-bottom: 3rem; scroll-margin-top: 5rem; }
 .day h2 {
-  font-size: 20px; font-weight: 600; color: var(--accent);
-  margin-bottom: 24px; padding-bottom: 8px;
+  font-size: 1.25rem; font-weight: 600; color: var(--accent);
+  margin-bottom: 1.5rem; padding-bottom: 0.5rem;
   border-bottom: 2px solid var(--border);
   transition: color .3s, border-color .3s;
 }'''
 
-
 def _post_css():
     return '''/* ── Post card ──────────────────────────────────── */
 .post {
-  margin-bottom: 16px; padding: 16px 20px; border-radius: 12px;
-  border: 1px solid var(--border); scroll-margin-top: 70px;
+  margin-bottom: 1rem; padding: 1rem 1.25rem; border-radius: 0.75rem;
+  border: 1px solid var(--border); scroll-margin-top: 4.375rem;
   transition: border-color .3s, background .3s;
 }
 .post.reply { background: var(--reply-bg); }
 .post-meta {
-  display: flex; align-items: center; gap: 6px;
-  margin-bottom: 8px; font-size: 13px; color: var(--muted);
+  display: flex; align-items: center; gap: 0.375rem;
+  margin-bottom: 0.5rem; font-size: 0.8125rem; color: var(--muted);
 }
 .post-meta time { font-weight: 500; }
 .reply-badge {
-  font-size: 11px; font-weight: 600; color: var(--accent);
-  padding: 1px 6px; border-radius: 4px;
+  font-size: 0.6875rem; font-weight: 600; color: var(--accent);
+  padding: 0.0625rem 0.375rem; border-radius: 0.25rem;
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 a.reply-badge { text-decoration: none; transition: background .2s; }
 a.reply-badge:hover { background: color-mix(in srgb, var(--accent) 20%, transparent); }
 .post-link {
   margin-left: auto; color: var(--link-icon); text-decoration: none;
-  font-size: 12px; opacity: 0; transition: opacity .2s;
+  font-size: 0.75rem; opacity: 0; transition: opacity .2s;
 }
 .post:hover .post-link { opacity: 1; }
 .post-link:hover { color: var(--accent); }
 .quote-link {
-  display: inline-block; margin-top: 10px; font-size: 13px; font-weight: 500;
-  color: var(--accent); text-decoration: none; padding: 3px 10px;
-  border-radius: 6px; border: 1px solid var(--border);
+  display: inline-block; margin-top: 0.625rem; font-size: 0.8125rem; font-weight: 500;
+  color: var(--accent); text-decoration: none; padding: 0.1875rem 0.625rem;
+  border-radius: 0.375rem; border: 1px solid var(--border);
   transition: background .2s, border-color .2s;
 }
 .quote-link:hover {
@@ -479,56 +512,53 @@ a.reply-badge:hover { background: color-mix(in srgb, var(--accent) 20%, transpar
   border-color: var(--accent);
 }'''
 
-
 def _content_css():
     return '''/* ── Content ────────────────────────────────────── */
 .post-content {
-  font-size: 15px; line-height: 1.7;
+  font-size: 0.9375rem; line-height: 1.7;
   word-wrap: break-word; overflow-wrap: break-word;
 }
-.post-content p { margin-bottom: 8px; }
+.post-content p { margin-bottom: 0.5rem; }
 .post-content p:last-child { margin-bottom: 0; }
 .post-content a { color: var(--accent); word-break: break-all; }'''
 
-
 def _image_css():
     return '''/* ── Images ─────────────────────────────────────── */
-.post-images { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+.post-images { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
 .post-images img {
-  max-width: 100%; height: auto; border-radius: 8px;
+  max-width: 100%; height: auto; border-radius: 0.5rem;
   border: 1px solid var(--border);
 }'''
 
-
 def _calendar_sidebar_css():
     return '''/* ── Calendar sidebar ────────────────────────────── */
-.cal-sidebar { flex: 0 0 220px; position: sticky; top: 70px; }
+.cal-sidebar { flex: 0 0 220px; position: sticky; top: 4.375rem; }
 #calendar {
-  border: 1px solid var(--border); border-radius: 10px;
-  padding: 12px; overflow: hidden; transition: border-color .3s;
+  border: 1px solid var(--border); border-radius: 0.625rem;
+  padding: 0.75rem; overflow: hidden; transition: border-color .3s;
 }
-.cal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
-.cal-label { font-size: 13px; font-weight: 600; color: var(--text); }
+.cal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.625rem; }
+.cal-label { font-size: 0.8125rem; font-weight: 600; color: var(--text); }
 .cal-nav {
-  background: none; border: 1px solid var(--border); border-radius: 6px;
-  padding: 0 8px; font-size: 14px; cursor: pointer; color: var(--muted);
-  line-height: 1; height: 26px;
+  background: none; border: 1px solid var(--border); border-radius: 0.375rem;
+  padding: 0 0.5rem; font-size: 0.875rem; cursor: pointer; color: var(--muted);
+  line-height: 1; height: 1.625rem;
   display: flex; align-items: center; justify-content: center;
   transition: color .2s, border-color .2s;
 }
 .cal-nav:hover { color: var(--accent); border-color: var(--accent); }
 .cal-nav:disabled { opacity: 0.25; cursor: default; pointer-events: none; }
-.cal-grid { width: 100%; border-collapse: collapse; font-size: 12px; }
-.cal-grid th { font-weight: 500; color: var(--muted); padding: 2px 0; text-align: center; font-size: 11px; }
-.cal-grid td { text-align: center; padding: 3px 0; color: var(--muted); font-size: 12px; }
+.cal-grid { width: 100%; border-collapse: collapse; font-size: 0.75rem; }
+.cal-grid th { font-weight: 500; color: var(--muted); padding: 0.125rem 0; text-align: center; font-size: 0.6875rem; }
+.cal-grid td { text-align: center; padding: 0.1875rem 0; color: var(--muted); font-size: 0.75rem; }
 .cal-grid td a {
-  display: inline-block; width: 24px; height: 24px; line-height: 24px;
+  display: flex; align-items: center; justify-content: center;
+  width: 1.5rem; height: 1.5rem; margin: 0 auto;
   border-radius: 50%; text-decoration: none; color: var(--text);
-  font-weight: 500; font-size: 12px; transition: background .2s, color .2s;
+  font-weight: 500; font-size: 0.75rem; transition: background .2s, color .2s;
 }
 .cal-grid td a:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); color: var(--accent); }
 .cal-grid td a.active { color: var(--accent); font-weight: 600; }'''
-
 
 def _cal_modal_css():
     return '''/* ── Calendar modal (mobile) ────────────────────── */
@@ -539,17 +569,16 @@ def _cal_modal_css():
 }
 .cal-modal-overlay[hidden] { display: none; }
 .cal-modal-box {
-  background: var(--bg); border-radius: 14px; padding: 20px;
+  background: var(--bg); border-radius: 0.875rem; padding: 1.25rem;
   width: 300px; cursor: default; transition: background .3s;
 }
-.cal-modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
-.cal-modal-title { font-size: 15px; font-weight: 600; color: var(--text); }
+.cal-modal-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+.cal-modal-title { font-size: 0.9375rem; font-weight: 600; color: var(--text); }
 .cal-modal-close {
-  background: none; border: none; font-size: 22px; cursor: pointer;
+  background: none; border: none; font-size: 1.375rem; cursor: pointer;
   color: var(--muted); padding: 0; line-height: 1;
 }
 .cal-modal-close:hover { color: var(--text); }'''
-
 
 def _lightbox_css():
     return '''/* ── Image lightbox ─────────────────────────────── */
@@ -559,15 +588,14 @@ def _lightbox_css():
   display: flex; align-items: center; justify-content: center; cursor: pointer;
 }
 .modal-overlay[hidden] { display: none; }
-.modal-overlay img { max-width: 90vw; max-height: 90vh; object-fit: contain; border-radius: 4px; cursor: default; }
+.modal-overlay img { max-width: 90vw; max-height: 90vh; object-fit: contain; border-radius: 0.25rem; cursor: default; }
 .modal-close {
-  position: fixed; top: 16px; right: 16px;
-  background: none; border: none; font-size: 32px; color: #fff;
+  position: fixed; top: 1rem; right: 1rem;
+  background: none; border: none; font-size: 2rem; color: #fff;
   cursor: pointer; opacity: 0.6; z-index: 201; line-height: 1;
   transition: opacity .2s;
 }
 .modal-close:hover { opacity: 1; }'''
-
 
 def _responsive_css(cal_visible):
     parts = ['/* ── Responsive ─────────────────────────────────── */',
@@ -576,12 +604,12 @@ def _responsive_css(cal_visible):
         parts.append('  .cal-sidebar { display: none; }')
         parts.append('  .cal-toggle { display: inline-flex; align-items: center; }')
     parts.extend([
-        '  .page-wrap { padding: 24px 16px 60px; }',
+        '  .page-wrap { padding: 1.5rem 1rem 3.75rem; }',
         '  main { flex: none; max-width: none; }',
         '  .page-wrap { display: block; }',
-        '  .post { padding: 12px 14px; }',
-        '  .post-content { font-size: 14px; }',
-        '  .day h2 { font-size: 18px; }',
+        '  .post { padding: 0.75rem 0.875rem; }',
+        '  .post-content { font-size: 0.875rem; }',
+        '  .day h2 { font-size: 1.125rem; }',
         '}',
     ])
     return '\n'.join(parts)
@@ -595,6 +623,7 @@ def _print_css(cal_visible):
 
 
 def generate_style_css(cfg):
+    has_cal = 'calendar' in cfg['layout'].get('sidebar', [])
     parts = [
         _theme_vars(cfg),
         _reset_css(cfg['font']['family']),
@@ -605,13 +634,13 @@ def generate_style_css(cfg):
         _content_css(),
         _image_css(),
     ]
-    if cfg['calendar']['visible']:
+    if has_cal:
         parts.append(_cal_toggle_css())
         parts.append(_calendar_sidebar_css())
         parts.append(_cal_modal_css())
     parts.append(_lightbox_css())
-    parts.append(_responsive_css(cfg['calendar']['visible']))
-    parts.append(_print_css(cfg['calendar']['visible']))
+    parts.append(_responsive_css(has_cal))
+    parts.append(_print_css(has_cal))
     return '\n\n'.join(parts) + '\n'
 
 THEME_TOGGLE_JS = '''(function() {
@@ -758,9 +787,9 @@ CALENDAR_MODAL_JS = '''(function() {
 
 def generate_theme_js(cfg):
     parts = []
-    if cfg['dark_mode_toggle']['visible']:
+    if 'dark_mode_toggle' in cfg['layout'].get('header', []):
         parts.append(THEME_TOGGLE_JS)
-    if cfg['calendar']['visible']:
+    if 'calendar' in cfg['layout'].get('sidebar', []):
         parts.append(CALENDAR_JS)
         parts.append(CALENDAR_MODAL_JS)
     parts.append(LIGHTBOX_JS)


### PR DESCRIPTION
## Changes
- **Config system** - `config.json` with `layout`/`widgets` structure. Widgets placed via `header`/`sidebar`/`content` arrays. `--config` CLI flag. Optional config file (falls back to defaults).
- **Quick nav widget** - "Today / Week / Month / Year" links in the sidebar that scroll to the nearest post for each period.
- **Calendar sidebar** - Sticky month calendar with highlighted post days. Collapsible to a modal on mobile. Prev/next navigation.
- **Image lightbox** - Click images for full-size preview. Dismiss via close button, outside click, or Escape.
- **Reply navigation** - Reply badges link to the parent post on the same page when available.
- **Configurable theming** - `border_radius`, `base_font_size`, and full `theme.light`/`theme.dark` color palettes in config.
- **Font configurability** - Google Fonts or custom CSS URL. Configurable family and weights.
- **Timestamp fixes** - UTC to local timezone conversion. `<time title="...">` tooltips on hover.
- **URL fixes** - Bluesky facets applied at fetch time so `github.com/...` becomes `https://github.com/...`. Trailing punctuation stripped from linkified URLs.
- **HTML sanitization** - Only `http(s)://` URLs are linked. All user content goes through `_escape()` before rendering.
- **`fetch_bsky.py --all`** - Re-fetches everything from scratch using a temp directory. Existing archive untouched on failure.
- **Mobile sidebar modal** - `⋮` button replaces "Cal" text. Modal shows all sidebar widgets (calendar + quick nav). Prev/next work via re-cloning.
- **CSS units** - All font sizes in `rem`, spacing in `rem`/`em`. Root font size set on `<html>` for proportional scaling.
- **config.md** - Full configuration reference documenting every config field.
- **README** - Setup, usage, deployment, and cron instructions.
- **`run.sh`** - Pipeline script for cron (fetch, generate, deploy).
- **Zero external dependencies** - Only Python 3 stdlib.
